### PR TITLE
fix: Add graceful MCP server shutdown handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -52,4 +52,23 @@ export async function startServer(): Promise<void> {
   // Start stdio transport
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Graceful shutdown: prevent the default SIGTERM/SIGINT behavior (immediate
+  // exit) so the MCP SDK can finish responding to any pending shutdown request.
+  // Also handle stdin EOF — the StdioServerTransport doesn't detect it, and the
+  // SyncClient polling timer would otherwise keep the process alive forever.
+  let shutdownInProgress = false;
+
+  const cleanup = async () => {
+    if (shutdownInProgress) return;
+    shutdownInProgress = true;
+
+    session.disconnect();
+    await server.close();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => { cleanup(); });
+  process.on('SIGINT', () => { cleanup(); });
+  process.stdin.on('end', () => { cleanup(); });
 }

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WPUser } from '../../src/wordpress/types.js';
 
-// --- Mock McpServer to capture constructor args ---
+// --- Mock McpServer to capture constructor args and close ---
 let capturedOptions: Record<string, unknown> | undefined;
+const mockServerClose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
   return {
@@ -10,6 +11,7 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
       capturedOptions = options;
       this.tool = vi.fn();
       this.connect = vi.fn().mockResolvedValue(undefined);
+      this.close = mockServerClose;
     }),
   };
 });
@@ -22,10 +24,12 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
 
 // --- Mock SessionManager ---
 const mockConnect = vi.fn<() => Promise<WPUser>>();
+const mockDisconnect = vi.fn();
 vi.mock('../../src/session/session-manager.js', () => {
   return {
     SessionManager: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
       this.connect = mockConnect;
+      this.disconnect = mockDisconnect;
     }),
   };
 });
@@ -102,5 +106,119 @@ describe('startServer()', () => {
     expect(capturedOptions!.instructions).toContain('wp_connect');
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe('graceful shutdown', () => {
+  const originalEnv = { ...process.env };
+  let processOnSpy: ReturnType<typeof vi.spyOn>;
+  let stdinOnSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  // Capture registered handlers so we can invoke them in tests
+  let signalHandlers: Record<string, (() => void)[]>;
+  let stdinHandlers: Record<string, (() => void)[]>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    delete process.env.WP_SITE_URL;
+    delete process.env.WP_USERNAME;
+    delete process.env.WP_APP_PASSWORD;
+
+    signalHandlers = {};
+    stdinHandlers = {};
+
+    processOnSpy = vi.spyOn(process, 'on').mockImplementation(((event: string, handler: () => void) => {
+      if (!signalHandlers[event]) signalHandlers[event] = [];
+      signalHandlers[event].push(handler);
+      return process;
+    }) as typeof process.on);
+
+    stdinOnSpy = vi.spyOn(process.stdin, 'on').mockImplementation(((event: string, handler: () => void) => {
+      if (!stdinHandlers[event]) stdinHandlers[event] = [];
+      stdinHandlers[event].push(handler);
+      return process.stdin;
+    }) as typeof process.stdin.on);
+
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as typeof process.exit);
+  });
+
+  afterEach(() => {
+    processOnSpy.mockRestore();
+    stdinOnSpy.mockRestore();
+    processExitSpy.mockRestore();
+    process.env = { ...originalEnv };
+  });
+
+  it('installs SIGTERM, SIGINT, and stdin end handlers', async () => {
+    const { startServer } = await import('../../src/server.js');
+    await startServer();
+
+    expect(signalHandlers['SIGTERM']).toHaveLength(1);
+    expect(signalHandlers['SIGINT']).toHaveLength(1);
+    expect(stdinHandlers['end']).toHaveLength(1);
+  });
+
+  it('disconnects session and closes server on SIGTERM', async () => {
+    const { startServer } = await import('../../src/server.js');
+    await startServer();
+
+    // Trigger the SIGTERM handler
+    signalHandlers['SIGTERM'][0]();
+
+    // Allow the async cleanup to complete
+    await vi.waitFor(() => {
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
+    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockServerClose).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects session and closes server on SIGINT', async () => {
+    const { startServer } = await import('../../src/server.js');
+    await startServer();
+
+    signalHandlers['SIGINT'][0]();
+
+    await vi.waitFor(() => {
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
+    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockServerClose).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects session and closes server on stdin end', async () => {
+    const { startServer } = await import('../../src/server.js');
+    await startServer();
+
+    stdinHandlers['end'][0]();
+
+    await vi.waitFor(() => {
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
+    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockServerClose).toHaveBeenCalledOnce();
+  });
+
+  it('only runs cleanup once even if triggered multiple times', async () => {
+    const { startServer } = await import('../../src/server.js');
+    await startServer();
+
+    // Trigger both SIGTERM and stdin end simultaneously
+    signalHandlers['SIGTERM'][0]();
+    stdinHandlers['end'][0]();
+
+    await vi.waitFor(() => {
+      expect(processExitSpy).toHaveBeenCalled();
+    });
+
+    // disconnect and close should only be called once despite two triggers
+    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockServerClose).toHaveBeenCalledOnce();
+    expect(processExitSpy).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Handle SIGTERM/SIGINT signals and stdin EOF in `src/server.ts` to shut down gracefully instead of being killed mid-handshake
- Cleanup disconnects the WordPress session (stops sync polling, clears Y.Doc listeners), closes the MCP server, then exits
- Re-entrancy guard prevents double cleanup when multiple shutdown signals arrive simultaneously

Partial mitigation for [anthropics/claude-code#18127](https://github.com/anthropics/claude-code/issues/18127). The full fix requires Claude Code to distinguish "failed during use" from "disconnected during intentional restart."

## Test plan

- [x] New tests verify SIGTERM, SIGINT, and stdin-end handlers are installed
- [x] New tests verify cleanup disconnects session and closes server
- [x] New test verifies re-entrancy guard (only cleans up once despite multiple triggers)
- [x] All 393 existing tests pass
- [x] TypeScript typecheck passes
- [ ] Manual: start MCP server, connect to WP, open a post, kill with SIGTERM — should exit cleanly