### PR TITLE
feat: Add media upload and image insertion support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,10 @@ Claude Code  <--stdio-->  MCP Server (Node.js)  <--HTTP polling-->  WordPress
 - `src/index.ts` — Entry point: CLI flags (`--version`, `--help`, `setup`) then MCP server
 - `src/server.ts` — MCP server setup, tool registration, version export
 - `src/cli/setup.ts` — Interactive setup wizard (credential validation, outputs `claude mcp add` command)
-- `src/wordpress/` — REST API client, HTTP polling sync client
+- `src/wordpress/` — REST API client, HTTP polling sync client, MIME type detection
 - `src/yjs/` — Y.Doc management, block ↔ Yjs conversion, sync protocol encoding
 - `src/session/` — Connection lifecycle, awareness/presence
-- `src/tools/` — MCP tool handlers (connect, posts [open/close/create], read, edit, status)
+- `src/tools/` — MCP tool handlers (connect, posts [open/close/create], read, edit, media, status)
 - `src/blocks/` — Gutenberg HTML parser, Claude-friendly renderer
 - `tests/` — Unit and integration tests
 
@@ -122,6 +122,24 @@ The version is injected at build time: `tsup.config.ts` reads `package.json` and
 - `WP_SITE_URL` — WordPress site URL (optional, can use `wp_connect` tool instead)
 - `WP_USERNAME` — WordPress username
 - `WP_APP_PASSWORD` — WordPress Application Password
+
+## Media Upload
+
+The `wp_upload_media` tool uploads a local file to the WordPress media library via `POST /wp/v2/media`. It returns the attachment ID, URL, MIME type, and dimensions, along with block insertion hints.
+
+Different media block types use different attribute names for the media reference:
+
+| Block | ID attr | URL attr | Extra required attrs |
+|-------|---------|----------|---------------------|
+| `core/image` | `id` | `url` | |
+| `core/video` | `id` | `src` | |
+| `core/audio` | `id` | `src` | |
+| `core/cover` | `id` | `url` | `backgroundType: "image"/"video"` |
+| `core/media-text` | `mediaId` | `mediaUrl` | `mediaType: "image"/"video"` |
+| `core/file` | `id` | `href` | |
+| `core/gallery` | N/A | N/A | Uses inner `core/image` blocks |
+
+The tool response includes a context-appropriate insertion hint based on the uploaded file's MIME type. MIME type detection is handled by `src/wordpress/mime-types.ts` using a static extension-to-MIME map (no external dependencies). Supported formats include common image, video, audio, and document types.
 
 ## MCP Server Usage
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { registerReadTools } from './tools/read.js';
 import { registerEditTools } from './tools/edit.js';
 import { registerStatusTools } from './tools/status.js';
 import { registerBlockTypeTools } from './tools/block-types.js';
+import { registerMediaTools } from './tools/media.js';
 
 declare const __PKG_VERSION__: string;
 
@@ -48,6 +49,7 @@ export async function startServer(): Promise<void> {
   registerEditTools(server, session);
   registerStatusTools(server, session);
   registerBlockTypeTools(server, session);
+  registerMediaTools(server, session);
 
   // Start stdio transport
   const transport = new StdioServerTransport();

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -5,6 +5,8 @@
  * Lifecycle: connect → openPost → edit/read → closePost → disconnect
  */
 
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import * as Y from 'yjs';
 import { DocumentManager } from '../yjs/document-manager.js';
 import { WordPressApiClient } from '../wordpress/api-client.js';
@@ -25,8 +27,10 @@ import { buildAwarenessState, parseCollaborators } from './awareness.js';
 import { DEFAULT_SYNC_CONFIG } from '../wordpress/types.js';
 import type { Block, CollaboratorInfo, AwarenessLocalState } from '../yjs/types.js';
 import { BlockTypeRegistry } from '../yjs/block-type-registry.js';
+import { getMimeType } from '../wordpress/mime-types.js';
 import type {
   WordPressConfig,
+  WPMediaItem,
   WPUser,
   WPPost,
 } from '../wordpress/types.js';
@@ -709,6 +713,25 @@ export class SessionManager {
     this.doc!.transact(() => {
       this.documentManager.markSaved(this.doc!);
     }, LOCAL_ORIGIN);
+  }
+
+  // --- Media ---
+
+  /**
+   * Upload a local file to the WordPress media library.
+   * Returns the created media item with ID, URL, and metadata.
+   */
+  async uploadMedia(
+    filePath: string,
+    options?: { altText?: string; caption?: string; title?: string },
+  ): Promise<WPMediaItem> {
+    this.requireState('connected', 'editing');
+
+    const fileName = basename(filePath);
+    const mimeType = getMimeType(fileName);
+    const fileData = await readFile(filePath);
+
+    return this.apiClient!.uploadMedia(fileData, fileName, mimeType, options);
   }
 
   // --- Status ---

--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionManager } from '../session/session-manager.js';
+import { getMediaCategory } from '../wordpress/mime-types.js';
+import type { WPMediaItem } from '../wordpress/types.js';
+
+/**
+ * Build a block insertion hint based on the uploaded media's MIME type.
+ * Shows the primary block type with the exact attributes needed,
+ * plus alternative block types that also accept this media category.
+ */
+function buildInsertionHint(media: WPMediaItem): string {
+  const category = getMediaCategory(media.mime_type);
+  const lines: string[] = [];
+
+  switch (category) {
+    case 'image': {
+      const imageAttrs: Record<string, unknown> = { id: media.id, url: media.source_url };
+      if (media.alt_text) imageAttrs.alt = media.alt_text;
+      lines.push('To insert as a block, use wp_insert_block with:');
+      lines.push(`  name: "core/image", attributes: ${JSON.stringify(imageAttrs)}`);
+      lines.push('Other blocks that accept images: core/cover (id + url), core/media-text (mediaId + mediaUrl + mediaType: "image")');
+      break;
+    }
+    case 'video':
+      lines.push('To insert as a block, use wp_insert_block with:');
+      lines.push(`  name: "core/video", attributes: { "id": ${media.id}, "src": "${media.source_url}" }`);
+      lines.push('Other blocks that accept videos: core/cover (id + url + backgroundType: "video"), core/media-text (mediaId + mediaUrl + mediaType: "video")');
+      break;
+    case 'audio':
+      lines.push('To insert as a block, use wp_insert_block with:');
+      lines.push(`  name: "core/audio", attributes: { "id": ${media.id}, "src": "${media.source_url}" }`);
+      break;
+    default:
+      lines.push('To insert as a block, use wp_insert_block with:');
+      lines.push(`  name: "core/file", attributes: { "id": ${media.id}, "href": "${media.source_url}" }`);
+      break;
+  }
+
+  return lines.join('\n');
+}
+
+export function registerMediaTools(server: McpServer, session: SessionManager): void {
+  server.tool(
+    'wp_upload_media',
+    'Upload a local file to the WordPress media library. Returns the attachment ID and URL for use with wp_insert_block (e.g., core/image, core/video, core/audio, core/file).',
+    {
+      filePath: z.string().describe('Absolute path to the local file to upload'),
+      altText: z.string().optional().describe('Alt text for the media (important for image accessibility)'),
+      title: z.string().optional().describe('Title for the media item'),
+      caption: z.string().optional().describe('Caption for the media item'),
+    },
+    async ({ filePath, altText, title, caption }) => {
+      try {
+        const media = await session.uploadMedia(filePath, { altText, title, caption });
+        const lines = [
+          'Uploaded successfully.',
+          '',
+          `Attachment ID: ${media.id}`,
+          `URL: ${media.source_url}`,
+          `MIME type: ${media.mime_type}`,
+        ];
+
+        if (media.alt_text) {
+          lines.push(`Alt text: ${media.alt_text}`);
+        }
+
+        if (media.media_details.width && media.media_details.height) {
+          lines.push(`Dimensions: ${media.media_details.width}x${media.media_details.height}`);
+        }
+
+        lines.push('');
+        lines.push(buildInsertionHint(media));
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Failed to upload media: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/wordpress/api-client.ts
+++ b/src/wordpress/api-client.ts
@@ -1,6 +1,7 @@
 import type {
   WordPressConfig,
   WPBlockType,
+  WPMediaItem,
   WPPost,
   WPUser,
   SyncPayload,
@@ -103,6 +104,30 @@ export class WordPressApiClient {
   }
 
   /**
+   * Upload a file to the WordPress media library.
+   * POST /wp/v2/media (multipart/form-data)
+   */
+  async uploadMedia(
+    fileData: Buffer,
+    fileName: string,
+    mimeType: string,
+    options?: { altText?: string; caption?: string; title?: string },
+  ): Promise<WPMediaItem> {
+    const formData = new FormData();
+    const blob = new Blob([fileData], { type: mimeType });
+    formData.append('file', blob, fileName);
+
+    if (options?.title) formData.append('title', options.title);
+    if (options?.altText) formData.append('alt_text', options.altText);
+    if (options?.caption) formData.append('caption', options.caption);
+
+    return this.apiFetch<WPMediaItem>('/wp/v2/media', {
+      method: 'POST',
+      body: formData,
+    });
+  }
+
+  /**
    * Send a sync payload and receive response.
    * POST /wp-sync/v1/updates
    */
@@ -143,8 +168,11 @@ export class WordPressApiClient {
       Accept: 'application/json',
     };
 
-    // Add Content-Type for requests with a body
-    if (options?.method === 'POST' || options?.method === 'PUT') {
+    // Add Content-Type for JSON requests (skip for FormData — fetch auto-sets the boundary)
+    if (
+      (options?.method === 'POST' || options?.method === 'PUT') &&
+      !(options?.body instanceof FormData)
+    ) {
       headers['Content-Type'] = 'application/json';
     }
 

--- a/src/wordpress/mime-types.ts
+++ b/src/wordpress/mime-types.ts
@@ -1,0 +1,85 @@
+/**
+ * MIME type detection for WordPress media uploads.
+ *
+ * Maps file extensions to MIME types for the media types WordPress accepts.
+ * Uses a static lookup table — no external dependencies.
+ */
+
+import { extname } from 'node:path';
+
+/** Media category derived from MIME type prefix. */
+export type MediaCategory = 'image' | 'video' | 'audio' | 'application';
+
+/** Map of file extensions to MIME types for WordPress-supported media. */
+const MIME_TYPES: Record<string, string> = {
+  // Images
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff',
+  '.avif': 'image/avif',
+  '.heic': 'image/heic',
+  // Video
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.avi': 'video/avi',
+  '.wmv': 'video/x-ms-wmv',
+  '.webm': 'video/webm',
+  '.ogv': 'video/ogg',
+  '.3gp': 'video/3gpp',
+  // Audio
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.flac': 'audio/flac',
+  '.m4a': 'audio/mp4',
+  '.aac': 'audio/aac',
+  '.wma': 'audio/x-ms-wma',
+  '.mid': 'audio/midi',
+  '.midi': 'audio/midi',
+  // Documents
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.odt': 'application/vnd.oasis.opendocument.text',
+  '.ods': 'application/vnd.oasis.opendocument.spreadsheet',
+  '.odp': 'application/vnd.oasis.opendocument.presentation',
+};
+
+/**
+ * Get the MIME type for a file based on its extension.
+ * Throws if the extension is not in the supported set.
+ */
+export function getMimeType(fileName: string): string {
+  const ext = extname(fileName).toLowerCase();
+  const mime = MIME_TYPES[ext];
+  if (!mime) {
+    throw new Error(
+      `Unsupported file type: ${ext || '(no extension)'}. ` +
+      `Supported types: ${Object.keys(MIME_TYPES).join(', ')}`,
+    );
+  }
+  return mime;
+}
+
+/**
+ * Derive the media category from a MIME type string.
+ * Returns 'image', 'video', 'audio', or 'application'.
+ */
+export function getMediaCategory(mimeType: string): MediaCategory {
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('video/')) return 'video';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  return 'application';
+}

--- a/src/wordpress/types.ts
+++ b/src/wordpress/types.ts
@@ -105,6 +105,23 @@ export interface WPBlockType {
   allowed_blocks?: string[] | null;
 }
 
+// --- Media API Types ---
+
+/** WordPress media item as returned by POST /wp/v2/media. */
+export interface WPMediaItem {
+  id: number;
+  source_url: string;
+  title: { rendered: string; raw?: string };
+  caption: { rendered: string; raw?: string };
+  alt_text: string;
+  mime_type: string;
+  media_details: {
+    width?: number;
+    height?: number;
+    sizes?: Record<string, { source_url: string; width: number; height: number }>;
+  };
+}
+
 // --- Connection Config ---
 
 export interface WordPressConfig {

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WordPressApiClient, WordPressApiError } from '../../src/wordpress/api-client.js';
-import type { SyncPayload, WPBlockType, WPPost, WPUser } from '../../src/wordpress/types.js';
+import type { SyncPayload, WPBlockType, WPMediaItem, WPPost, WPUser } from '../../src/wordpress/types.js';
 
 // Helper to build a mock Response
 function mockResponse(body: unknown, init?: { status?: number; statusText?: string }): Response {
@@ -377,6 +377,104 @@ describe('WordPressApiClient', () => {
         expect(apiErr.message).not.toContain('Collaborative editing');
         expect(apiErr.message).toContain('404');
       }
+    });
+  });
+
+  describe('uploadMedia', () => {
+    const fakeMediaItem: WPMediaItem = {
+      id: 101,
+      source_url: 'https://example.com/wp-content/uploads/2026/03/test.jpg',
+      title: { rendered: 'test', raw: 'test' },
+      caption: { rendered: '', raw: '' },
+      alt_text: 'A test image',
+      mime_type: 'image/jpeg',
+      media_details: { width: 800, height: 600, sizes: {} },
+    };
+
+    it('posts to /wp/v2/media with FormData body', async () => {
+      fetchMock.mockResolvedValue(mockResponse(fakeMediaItem));
+      const client = createClient();
+      const fileData = Buffer.from('fake image data');
+      const result = await client.uploadMedia(fileData, 'test.jpg', 'image/jpeg');
+
+      const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://example.com/wp-json/wp/v2/media');
+      expect(options.method).toBe('POST');
+      expect(options.body).toBeInstanceOf(FormData);
+      expect(result).toEqual(fakeMediaItem);
+    });
+
+    it('does not manually set Content-Type for FormData', async () => {
+      fetchMock.mockResolvedValue(mockResponse(fakeMediaItem));
+      const client = createClient();
+      await client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg');
+
+      const options = fetchMock.mock.calls[0][1] as RequestInit;
+      expect((options.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    });
+
+    it('includes Authorization header', async () => {
+      fetchMock.mockResolvedValue(mockResponse(fakeMediaItem));
+      const client = createClient();
+      await client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg');
+
+      const expectedAuth = `Basic ${btoa('admin:xxxx yyyy zzzz')}`;
+      const options = fetchMock.mock.calls[0][1] as RequestInit;
+      expect((options.headers as Record<string, string>).Authorization).toBe(expectedAuth);
+    });
+
+    it('appends optional metadata to FormData', async () => {
+      fetchMock.mockResolvedValue(mockResponse(fakeMediaItem));
+      const client = createClient();
+      await client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg', {
+        altText: 'Alt text',
+        title: 'My Image',
+        caption: 'A caption',
+      });
+
+      const options = fetchMock.mock.calls[0][1] as RequestInit;
+      const formData = options.body as FormData;
+      expect(formData.get('alt_text')).toBe('Alt text');
+      expect(formData.get('title')).toBe('My Image');
+      expect(formData.get('caption')).toBe('A caption');
+    });
+
+    it('does not append undefined optional fields', async () => {
+      fetchMock.mockResolvedValue(mockResponse(fakeMediaItem));
+      const client = createClient();
+      await client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg');
+
+      const options = fetchMock.mock.calls[0][1] as RequestInit;
+      const formData = options.body as FormData;
+      expect(formData.get('alt_text')).toBeNull();
+      expect(formData.get('title')).toBeNull();
+      expect(formData.get('caption')).toBeNull();
+    });
+
+    it('throws on auth failure', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(
+          { code: 'rest_forbidden', message: 'Forbidden' },
+          { status: 401, statusText: 'Unauthorized' },
+        ),
+      );
+      const client = createClient();
+      await expect(
+        client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg'),
+      ).rejects.toThrow(WordPressApiError);
+    });
+
+    it('throws on server error (e.g., file too large)', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(
+          { code: 'rest_upload_file_too_big', message: 'File too large' },
+          { status: 413, statusText: 'Payload Too Large' },
+        ),
+      );
+      const client = createClient();
+      await expect(
+        client.uploadMedia(Buffer.from('data'), 'test.jpg', 'image/jpeg'),
+      ).rejects.toThrow(WordPressApiError);
     });
   });
 

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -10,6 +10,7 @@ const mockListPosts = vi.fn<() => Promise<WPPost[]>>();
 const mockCreatePost = vi.fn<() => Promise<WPPost>>();
 const mockSendSyncUpdate = vi.fn();
 const mockGetBlockTypes = vi.fn<() => Promise<unknown[]>>();
+const mockUploadMedia = vi.fn();
 
 vi.mock('../../src/wordpress/api-client.js', () => {
   return {
@@ -21,9 +22,16 @@ vi.mock('../../src/wordpress/api-client.js', () => {
       this.createPost = mockCreatePost;
       this.sendSyncUpdate = mockSendSyncUpdate;
       this.getBlockTypes = mockGetBlockTypes;
+      this.uploadMedia = mockUploadMedia;
     }),
   };
 });
+
+// --- Mock node:fs/promises for uploadMedia tests ---
+const mockReadFile = vi.fn<() => Promise<Buffer>>();
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+}));
 
 // --- Mock the sync client ---
 const mockSyncStart = vi.fn();
@@ -981,6 +989,102 @@ describe('SessionManager', () => {
         s.disconnect();
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('uploadMedia()', () => {
+    const fakeMediaResponse = {
+      id: 101,
+      source_url: 'https://example.com/wp-content/uploads/2026/03/test.jpg',
+      title: { rendered: 'test', raw: 'test' },
+      caption: { rendered: '', raw: '' },
+      alt_text: '',
+      mime_type: 'image/jpeg',
+      media_details: { width: 800, height: 600, sizes: {} },
+    };
+
+    beforeEach(() => {
+      mockReadFile.mockResolvedValue(Buffer.from('fake image data'));
+      mockUploadMedia.mockResolvedValue(fakeMediaResponse);
+    });
+
+    it('requires connected or editing state', async () => {
+      await expect(session.uploadMedia('/path/to/file.jpg')).rejects.toThrow(
+        /requires state connected or editing/,
+      );
+    });
+
+    it('works in connected state', async () => {
+      await connectSession(session);
+
+      const result = await session.uploadMedia('/path/to/photo.jpg');
+
+      expect(result).toEqual(fakeMediaResponse);
+      expect(mockReadFile).toHaveBeenCalledWith('/path/to/photo.jpg');
+      expect(mockUploadMedia).toHaveBeenCalledWith(
+        Buffer.from('fake image data'),
+        'photo.jpg',
+        'image/jpeg',
+        undefined,
+      );
+    });
+
+    it('works in editing state', async () => {
+      await connectAndOpen(session);
+
+      const result = await session.uploadMedia('/path/to/photo.png');
+
+      expect(result).toEqual(fakeMediaResponse);
+      expect(mockUploadMedia).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        'photo.png',
+        'image/png',
+        undefined,
+      );
+    });
+
+    it('passes optional metadata to API client', async () => {
+      await connectSession(session);
+
+      await session.uploadMedia('/path/to/photo.jpg', {
+        altText: 'Scenic view',
+        title: 'Sunset',
+        caption: 'At dusk',
+      });
+
+      expect(mockUploadMedia).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        'photo.jpg',
+        'image/jpeg',
+        { altText: 'Scenic view', title: 'Sunset', caption: 'At dusk' },
+      );
+    });
+
+    it('detects MIME type from file extension', async () => {
+      await connectSession(session);
+
+      await session.uploadMedia('/path/to/clip.mp4');
+      expect(mockUploadMedia).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        'clip.mp4',
+        'video/mp4',
+        undefined,
+      );
+    });
+
+    it('throws for unsupported file types', async () => {
+      await connectSession(session);
+
+      await expect(session.uploadMedia('/path/to/file.xyz')).rejects.toThrow(
+        /Unsupported file type/,
+      );
+    });
+
+    it('propagates file read errors', async () => {
+      await connectSession(session);
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT: no such file'));
+
+      await expect(session.uploadMedia('/path/to/missing.jpg')).rejects.toThrow('ENOENT');
     });
   });
 });

--- a/tests/unit/tools/helpers.ts
+++ b/tests/unit/tools/helpers.ts
@@ -8,7 +8,7 @@
 import { vi } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SessionManager, SessionState } from '../../../src/session/session-manager.js';
-import type { WPPost, WPUser } from '../../../src/wordpress/types.js';
+import type { WPMediaItem, WPPost, WPUser } from '../../../src/wordpress/types.js';
 import type { CollaboratorInfo } from '../../../src/yjs/types.js';
 
 export interface RegisteredTool {
@@ -59,6 +59,16 @@ export const fakePost: WPPost = {
   modified: '2026-01-01T00:00:00',
 };
 
+export const fakeMediaItem: WPMediaItem = {
+  id: 101,
+  source_url: 'https://example.com/wp-content/uploads/2026/03/test.jpg',
+  title: { rendered: 'test', raw: 'test' },
+  caption: { rendered: '', raw: '' },
+  alt_text: 'A test image',
+  mime_type: 'image/jpeg',
+  media_details: { width: 800, height: 600, sizes: {} },
+};
+
 export const fakeCollaborator: CollaboratorInfo = {
   id: 2,
   name: 'Alice',
@@ -105,6 +115,7 @@ export function createMockSession(overrides: {
     moveBlock: vi.fn(),
     replaceBlocks: vi.fn().mockResolvedValue(undefined),
     setTitle: vi.fn().mockResolvedValue(undefined),
+    uploadMedia: vi.fn().mockResolvedValue(fakeMediaItem),
     save: vi.fn(),
     getState: vi.fn().mockReturnValue(state),
     getSyncStatus: vi.fn().mockReturnValue(syncStatus),

--- a/tests/unit/tools/media.test.ts
+++ b/tests/unit/tools/media.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerMediaTools } from '../../../src/tools/media.js';
+import type { SessionManager } from '../../../src/session/session-manager.js';
+import {
+  createMockServer,
+  createMockSession,
+  fakeUser,
+  fakePost,
+  fakeMediaItem,
+} from './helpers.js';
+
+describe('media tools', () => {
+  let server: ReturnType<typeof createMockServer>;
+  let session: SessionManager;
+
+  beforeEach(() => {
+    server = createMockServer();
+    session = createMockSession({ state: 'editing', user: fakeUser, post: fakePost });
+    registerMediaTools(server as unknown as McpServer, session);
+  });
+
+  it('registers wp_upload_media tool', () => {
+    expect(server.registeredTools.has('wp_upload_media')).toBe(true);
+  });
+
+  describe('wp_upload_media', () => {
+    it('returns formatted response with image insertion hint', async () => {
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({
+        filePath: '/path/to/photo.jpg',
+      });
+
+      expect(session.uploadMedia).toHaveBeenCalledWith('/path/to/photo.jpg', {
+        altText: undefined,
+        title: undefined,
+        caption: undefined,
+      });
+
+      const text = result.content[0].text;
+      expect(text).toContain('Uploaded successfully');
+      expect(text).toContain('Attachment ID: 101');
+      expect(text).toContain('https://example.com/wp-content/uploads/2026/03/test.jpg');
+      expect(text).toContain('image/jpeg');
+      expect(text).toContain('800x600');
+      expect(text).toContain('core/image');
+      expect(text).toContain('"id":101');
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('passes optional parameters to session', async () => {
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      await tool.handler({
+        filePath: '/path/to/photo.jpg',
+        altText: 'A scenic view',
+        title: 'Sunset Photo',
+        caption: 'Taken at dusk',
+      });
+
+      expect(session.uploadMedia).toHaveBeenCalledWith('/path/to/photo.jpg', {
+        altText: 'A scenic view',
+        title: 'Sunset Photo',
+        caption: 'Taken at dusk',
+      });
+    });
+
+    it('shows video insertion hint for video uploads', async () => {
+      const videoMedia = {
+        ...fakeMediaItem,
+        mime_type: 'video/mp4',
+        source_url: 'https://example.com/wp-content/uploads/2026/03/clip.mp4',
+        media_details: { width: 1920, height: 1080, sizes: {} },
+      };
+      (session.uploadMedia as ReturnType<typeof import('vitest').vi.fn>)
+        .mockResolvedValueOnce(videoMedia);
+
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/clip.mp4' });
+
+      const text = result.content[0].text;
+      expect(text).toContain('core/video');
+      expect(text).toContain('"src"');
+      expect(text).toContain('core/cover');
+      expect(text).toContain('core/media-text');
+    });
+
+    it('shows audio insertion hint for audio uploads', async () => {
+      const audioMedia = {
+        ...fakeMediaItem,
+        mime_type: 'audio/mpeg',
+        source_url: 'https://example.com/wp-content/uploads/2026/03/song.mp3',
+        media_details: {},
+      };
+      (session.uploadMedia as ReturnType<typeof import('vitest').vi.fn>)
+        .mockResolvedValueOnce(audioMedia);
+
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/song.mp3' });
+
+      const text = result.content[0].text;
+      expect(text).toContain('core/audio');
+      expect(text).toContain('"src"');
+      expect(text).not.toContain('core/cover');
+      expect(text).not.toContain('core/media-text');
+      expect(text).not.toContain('Dimensions');
+    });
+
+    it('shows file insertion hint for document uploads', async () => {
+      const pdfMedia = {
+        ...fakeMediaItem,
+        mime_type: 'application/pdf',
+        source_url: 'https://example.com/wp-content/uploads/2026/03/doc.pdf',
+        media_details: {},
+      };
+      (session.uploadMedia as ReturnType<typeof import('vitest').vi.fn>)
+        .mockResolvedValueOnce(pdfMedia);
+
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/doc.pdf' });
+
+      const text = result.content[0].text;
+      expect(text).toContain('core/file');
+      expect(text).toContain('"href"');
+      expect(text).not.toContain('Dimensions');
+    });
+
+    it('includes alt text in response and insertion hint', async () => {
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/photo.jpg' });
+
+      const text = result.content[0].text;
+      expect(text).toContain('Alt text: A test image');
+      // The insertion hint should include the alt text in attributes
+      expect(text).toContain('"alt":"A test image"');
+    });
+
+    it('returns error when upload fails', async () => {
+      (session.uploadMedia as ReturnType<typeof import('vitest').vi.fn>)
+        .mockRejectedValueOnce(new Error('File not found'));
+
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/missing.jpg' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to upload media');
+      expect(result.content[0].text).toContain('File not found');
+    });
+
+    it('returns error for unsupported file type', async () => {
+      (session.uploadMedia as ReturnType<typeof import('vitest').vi.fn>)
+        .mockRejectedValueOnce(new Error('Unsupported file type: .xyz'));
+
+      const tool = server.registeredTools.get('wp_upload_media')!;
+      const result = await tool.handler({ filePath: '/path/to/file.xyz' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unsupported file type');
+    });
+  });
+});

--- a/tests/unit/wordpress/mime-types.test.ts
+++ b/tests/unit/wordpress/mime-types.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { getMimeType, getMediaCategory } from '../../../src/wordpress/mime-types.js';
+
+describe('getMimeType', () => {
+  it('returns correct MIME type for common image extensions', () => {
+    expect(getMimeType('photo.jpg')).toBe('image/jpeg');
+    expect(getMimeType('photo.jpeg')).toBe('image/jpeg');
+    expect(getMimeType('logo.png')).toBe('image/png');
+    expect(getMimeType('animation.gif')).toBe('image/gif');
+    expect(getMimeType('modern.webp')).toBe('image/webp');
+    expect(getMimeType('vector.svg')).toBe('image/svg+xml');
+    expect(getMimeType('next-gen.avif')).toBe('image/avif');
+    expect(getMimeType('apple.heic')).toBe('image/heic');
+  });
+
+  it('returns correct MIME type for video extensions', () => {
+    expect(getMimeType('clip.mp4')).toBe('video/mp4');
+    expect(getMimeType('clip.m4v')).toBe('video/mp4');
+    expect(getMimeType('clip.mov')).toBe('video/quicktime');
+    expect(getMimeType('clip.webm')).toBe('video/webm');
+    expect(getMimeType('clip.avi')).toBe('video/avi');
+    expect(getMimeType('clip.ogv')).toBe('video/ogg');
+  });
+
+  it('returns correct MIME type for audio extensions', () => {
+    expect(getMimeType('song.mp3')).toBe('audio/mpeg');
+    expect(getMimeType('song.ogg')).toBe('audio/ogg');
+    expect(getMimeType('song.wav')).toBe('audio/wav');
+    expect(getMimeType('song.flac')).toBe('audio/flac');
+    expect(getMimeType('song.m4a')).toBe('audio/mp4');
+    expect(getMimeType('song.aac')).toBe('audio/aac');
+  });
+
+  it('returns correct MIME type for document extensions', () => {
+    expect(getMimeType('doc.pdf')).toBe('application/pdf');
+    expect(getMimeType('doc.doc')).toBe('application/msword');
+    expect(getMimeType('doc.docx')).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    expect(getMimeType('slides.pptx')).toBe('application/vnd.openxmlformats-officedocument.presentationml.presentation');
+    expect(getMimeType('data.xlsx')).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  });
+
+  it('handles uppercase extensions (case-insensitive)', () => {
+    expect(getMimeType('PHOTO.JPG')).toBe('image/jpeg');
+    expect(getMimeType('Image.PNG')).toBe('image/png');
+    expect(getMimeType('video.MP4')).toBe('video/mp4');
+  });
+
+  it('throws for unknown extensions', () => {
+    expect(() => getMimeType('file.xyz')).toThrow('Unsupported file type: .xyz');
+    expect(() => getMimeType('file.xyz')).toThrow('Supported types:');
+  });
+
+  it('throws for files with no extension', () => {
+    expect(() => getMimeType('Makefile')).toThrow('Unsupported file type: (no extension)');
+  });
+
+  it('handles paths with directories', () => {
+    expect(getMimeType('/path/to/photo.jpg')).toBe('image/jpeg');
+    expect(getMimeType('images/logo.png')).toBe('image/png');
+  });
+});
+
+describe('getMediaCategory', () => {
+  it('returns "image" for image MIME types', () => {
+    expect(getMediaCategory('image/jpeg')).toBe('image');
+    expect(getMediaCategory('image/png')).toBe('image');
+    expect(getMediaCategory('image/svg+xml')).toBe('image');
+  });
+
+  it('returns "video" for video MIME types', () => {
+    expect(getMediaCategory('video/mp4')).toBe('video');
+    expect(getMediaCategory('video/webm')).toBe('video');
+    expect(getMediaCategory('video/quicktime')).toBe('video');
+  });
+
+  it('returns "audio" for audio MIME types', () => {
+    expect(getMediaCategory('audio/mpeg')).toBe('audio');
+    expect(getMediaCategory('audio/ogg')).toBe('audio');
+    expect(getMediaCategory('audio/wav')).toBe('audio');
+  });
+
+  it('returns "application" for document/other MIME types', () => {
+    expect(getMediaCategory('application/pdf')).toBe('application');
+    expect(getMediaCategory('application/msword')).toBe('application');
+    expect(getMediaCategory('application/octet-stream')).toBe('application');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1.

- Adds `wp_upload_media` MCP tool that uploads local files to the WordPress media library via `POST /wp/v2/media`
- Returns attachment ID, URL, MIME type, dimensions, and **context-aware block insertion hints** showing the correct attribute names for each media block type
- Supports images, video, audio, and documents with a self-contained MIME type detection module (no external dependencies)
- Fixes `apiFetch` to skip `Content-Type: application/json` for `FormData` bodies, letting `fetch()` auto-set the multipart boundary

### Media block attribute mapping

Different blocks use different attribute names for media references — the tool response includes the correct hint based on the uploaded file's MIME type:

| Block | ID attr | URL attr | Hint shown for |
|-------|---------|----------|---------------|
| `core/image` | `id` | `url` | images |
| `core/video` | `id` | `src` | videos |
| `core/audio` | `id` | `src` | audio |
| `core/cover` | `id` | `url` | images, videos (secondary) |
| `core/media-text` | `mediaId` | `mediaUrl` | images, videos (secondary) |
| `core/file` | `id` | `href` | documents |

### Files changed

**New:**
- `src/wordpress/mime-types.ts` — Extension-to-MIME map with `getMimeType()` and `getMediaCategory()`
- `src/tools/media.ts` — `wp_upload_media` tool with block insertion hints
- `tests/unit/wordpress/mime-types.test.ts`
- `tests/unit/tools/media.test.ts`

**Modified:**
- `src/wordpress/types.ts` — `WPMediaItem` interface
- `src/wordpress/api-client.ts` — `uploadMedia()` method + FormData Content-Type fix
- `src/session/session-manager.ts` — `uploadMedia()` method (MIME check before file read)
- `src/server.ts` — Register media tools
- `CLAUDE.md` — Document media upload workflow and block attribute mapping

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (428 tests, including new MIME, API client, tool, and session manager tests)
- [x] `npm run build` succeeds
- [x] Manual end-to-end test: uploaded a PNG, inserted as `core/image` block, verified in Gutenberg