### PR TITLE
refactor: extract portable ToolDefinition and PromptDefinition interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ Claude Code  <--stdio-->  MCP Server (Node.js)  <--HTTP polling-->  WordPress
 - `src/wordpress/` — REST API client, HTTP polling sync client, command client, MIME types
 - `src/yjs/` — Y.Doc management, block ↔ Yjs conversion, sync protocol encoding
 - `src/session/` — Connection lifecycle, awareness/presence, command handler
-- `src/tools/` — MCP tool handlers
-- `src/prompts/` — MCP prompt handlers and content builders
+- `src/tools/` — Portable tool definitions (`ToolDefinition[]` arrays), registry, and MCP wiring
+- `src/prompts/` — Portable prompt definitions (`PromptDefinition[]` arrays), registry, content builders, and MCP wiring
 - `src/blocks/` — Gutenberg HTML parser, Claude-friendly renderer
 - `tests/` — Unit and integration tests
 
@@ -66,6 +66,23 @@ disconnected ──connect──→ connected ──openPost/createPost──→
 ### Sync Protocol
 
 Endpoint: `POST /wp-sync/v1/updates`. Each request sends local updates + awareness, receives remote updates + awareness + end_cursor. Update types: `sync_step1`, `sync_step2`, `update`, `compaction`.
+
+### Portable Tool & Prompt Definitions
+
+Tool and prompt definitions are decoupled from the MCP SDK so they can be consumed by both the MCP server and an external hosted orchestrator.
+
+- **`src/tools/definitions.ts`** — `ToolDefinition` interface. Each tool file exports a `ToolDefinition[]` array. `execute(session, input)` returns `string` (success), `ToolResult` (expected error with `isError`), or throws (unexpected error).
+- **`src/prompts/definitions.ts`** — `PromptDefinition` interface. Each prompt file exports a `PromptDefinition[]` array. `buildMessages(session, args)` returns simplified `{ role, content: string }` messages.
+- **`src/tools/registry.ts`** — Aggregates all tools into `allTools`, provides `registerAllTools(server, session)` for MCP wiring and lookup helpers (`getToolByName`, `getToolsForState`, `getToolsByTag`).
+- **`src/prompts/registry.ts`** — Same pattern for prompts. The MCP wrapper converts `PromptMessage.content` to `{ type: 'text', text }`.
+- **`src/server-instructions.ts`** — Extracted channel/base instructions as pure functions.
+- **Subpath exports** — `package.json` exports `./tools/definitions`, `./tools/registry`, `./prompts/definitions`, `./prompts/registry`, `./prompts/prompt-content`, `./session/session-manager`, `./server-instructions`, `./shared/commands`.
+
+### Adding a New Tool
+
+1. Add a `ToolDefinition` to the appropriate file in `src/tools/` (or create a new file)
+2. If new file: import and spread into `allTools` in `src/tools/registry.ts`
+3. Set `availableIn` (session states) and `tags` for hosted-server filtering
 
 ## Adding a New Command
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,15 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"exports": {
-		".": "./dist/index.js"
+		".": "./dist/index.js",
+		"./prompts/definitions": "./dist/prompts/definitions.js",
+		"./prompts/prompt-content": "./dist/prompts/prompt-content.js",
+		"./prompts/registry": "./dist/prompts/registry.js",
+		"./server-instructions": "./dist/server-instructions.js",
+		"./session/session-manager": "./dist/session/session-manager.js",
+		"./shared/commands": "./dist/shared/commands.js",
+		"./tools/definitions": "./dist/tools/definitions.js",
+		"./tools/registry": "./dist/tools/registry.js"
 	},
 	"sideEffects": false,
 	"author": "Gary Pendergast",

--- a/src/prompts/authoring.ts
+++ b/src/prompts/authoring.ts
@@ -15,7 +15,7 @@ export const authoringPrompts: PromptDefinition[] = [
 					'Target language (e.g., "Spanish", "French", "Japanese", "zh-CN")'
 				),
 		},
-		buildMessages: (session, { language }) => {
+		buildMessages: (session, { language }: { language: string }) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {

--- a/src/prompts/authoring.ts
+++ b/src/prompts/authoring.ts
@@ -1,27 +1,21 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
 import { buildTranslateContent } from './prompt-content.js';
 
-export function registerAuthoringPrompts(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerPrompt(
-		'translate',
-		{
-			description: 'Translate a WordPress post into another language.',
-			argsSchema: {
-				language: z
-					.string()
-					.trim()
-					.min(1)
-					.describe(
-						'Target language (e.g., "Spanish", "French", "Japanese", "zh-CN")'
-					),
-			},
+export const authoringPrompts: PromptDefinition[] = [
+	{
+		name: 'translate',
+		description: 'Translate a WordPress post into another language.',
+		argsSchema: {
+			language: z
+				.string()
+				.trim()
+				.min(1)
+				.describe(
+					'Target language (e.g., "Spanish", "French", "Japanese", "zh-CN")'
+				),
 		},
-		({ language }) => {
+		buildMessages: (session, { language }) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -29,11 +23,9 @@ export function registerAuthoringPrompts(
 					description: 'Translate a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to translate a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to translate a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -44,11 +36,9 @@ export function registerAuthoringPrompts(
 					description: 'Translate a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to translate a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to translate a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -61,14 +51,11 @@ export function registerAuthoringPrompts(
 				description: `Translate "${session.getTitle()}" into ${language}`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildTranslateContent(postContent, language),
-						},
+						role: 'user',
+						content: buildTranslateContent(postContent, language),
 					},
 				],
 			};
-		}
-	);
-}
+		},
+	},
+];

--- a/src/prompts/compose.ts
+++ b/src/prompts/compose.ts
@@ -1,18 +1,12 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
 import { buildComposeContent } from './prompt-content.js';
 
-export function registerComposePrompts(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerPrompt(
-		'compose',
-		{
-			description:
-				'Plan and outline a WordPress post through guided conversation.',
-		},
-		() => {
+export const composePrompts: PromptDefinition[] = [
+	{
+		name: 'compose',
+		description:
+			'Plan and outline a WordPress post through guided conversation.',
+		buildMessages: (session) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -20,11 +14,9 @@ export function registerComposePrompts(
 					description: 'Compose a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to plan and outline a WordPress post. Please connect to WordPress first using wp_connect, then open or create a post with wp_open_post or wp_create_post.',
-							},
+							role: 'user',
+							content:
+								'I want to plan and outline a WordPress post. Please connect to WordPress first using wp_connect, then open or create a post with wp_open_post or wp_create_post.',
 						},
 					],
 				};
@@ -35,11 +27,9 @@ export function registerComposePrompts(
 					description: 'Compose a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to plan and outline a WordPress post. Please open an existing post with wp_open_post or create a new one with wp_create_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to plan and outline a WordPress post. Please open an existing post with wp_open_post or create a new one with wp_create_post first.',
 						},
 					],
 				};
@@ -53,17 +43,14 @@ export function registerComposePrompts(
 				description: `Compose outline for "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildComposeContent(
-								postContent,
-								notesSupported
-							),
-						},
+						role: 'user',
+						content: buildComposeContent(
+							postContent,
+							notesSupported
+						),
 					},
 				],
 			};
-		}
-	);
-}
+		},
+	},
+];

--- a/src/prompts/definitions.ts
+++ b/src/prompts/definitions.ts
@@ -1,0 +1,48 @@
+import type { z } from 'zod';
+import type { SessionManager } from '../session/session-manager.js';
+
+/**
+ * A single message in a prompt response.
+ * Uses simplified `content: string` instead of the MCP SDK's
+ * `{ type: 'text', text }` object — the registry wrapper converts.
+ */
+export interface PromptMessage {
+	role: 'user' | 'assistant';
+	content: string;
+}
+
+/**
+ * Result returned by a prompt's buildMessages function.
+ */
+export interface PromptResult {
+	description: string;
+	messages: PromptMessage[];
+}
+
+/**
+ * Portable prompt definition that can be consumed by both the MCP server
+ * (via registerPromptDefinitions) and a hosted orchestrator.
+ */
+export interface PromptDefinition {
+	/** Prompt name (e.g., "review", "proofread") */
+	name: string;
+
+	/** Description shown to the model */
+	description: string;
+
+	/**
+	 * Optional Zod raw shape for prompt arguments.
+	 * Omit for prompts with no arguments.
+	 */
+	argsSchema?: z.ZodRawShape;
+
+	/**
+	 * Build the prompt messages for the given session state and arguments.
+	 * Handles state checks internally (returns guidance messages for
+	 * disconnected/connected states).
+	 */
+	buildMessages: (
+		session: SessionManager,
+		args: Record<string, string>
+	) => Promise<PromptResult> | PromptResult;
+}

--- a/src/prompts/definitions.ts
+++ b/src/prompts/definitions.ts
@@ -23,7 +23,8 @@ export interface PromptResult {
  * Portable prompt definition that can be consumed by both the MCP server
  * (via registerPromptDefinitions) and a hosted orchestrator.
  */
-export interface PromptDefinition {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: args validated by Zod at runtime
+export interface PromptDefinition<TArgs = any> {
 	/** Prompt name (e.g., "review", "proofread") */
 	name: string;
 
@@ -43,6 +44,6 @@ export interface PromptDefinition {
 	 */
 	buildMessages: (
 		session: SessionManager,
-		args: Record<string, string>
+		args: TArgs
 	) => Promise<PromptResult> | PromptResult;
 }

--- a/src/prompts/editing.ts
+++ b/src/prompts/editing.ts
@@ -1,27 +1,21 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
 import { buildEditContent, buildProofreadContent } from './prompt-content.js';
 
-export function registerEditingPrompts(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerPrompt(
-		'edit',
-		{
-			description: 'Edit a WordPress post with a specific editing focus.',
-			argsSchema: {
-				editingFocus: z
-					.string()
-					.trim()
-					.min(1)
-					.describe(
-						'A brief description of the editing focus or intent (e.g., "Make it more formal", "Improve the flow", "Condense the intro")'
-					),
-			},
+export const editingPrompts: PromptDefinition[] = [
+	{
+		name: 'edit',
+		description: 'Edit a WordPress post with a specific editing focus.',
+		argsSchema: {
+			editingFocus: z
+				.string()
+				.trim()
+				.min(1)
+				.describe(
+					'A brief description of the editing focus or intent (e.g., "Make it more formal", "Improve the flow", "Condense the intro")'
+				),
 		},
-		({ editingFocus }) => {
+		buildMessages: (session, { editingFocus }) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -29,11 +23,9 @@ export function registerEditingPrompts(
 					description: 'Edit a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to edit a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to edit a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -44,11 +36,9 @@ export function registerEditingPrompts(
 					description: 'Edit a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: "I want to edit a WordPress post. Please open a post with wp_open_post first, then I'll tell you what changes to make.",
-							},
+							role: 'user',
+							content:
+								"I want to edit a WordPress post. Please open a post with wp_open_post first, then I'll tell you what changes to make.",
 						},
 					],
 				};
@@ -61,24 +51,18 @@ export function registerEditingPrompts(
 				description: `Edit "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildEditContent(postContent, editingFocus),
-						},
+						role: 'user',
+						content: buildEditContent(postContent, editingFocus),
 					},
 				],
 			};
-		}
-	);
-
-	server.registerPrompt(
-		'proofread',
-		{
-			description:
-				'Proofread a WordPress post for grammar, spelling, punctuation, and style issues.',
 		},
-		() => {
+	},
+	{
+		name: 'proofread',
+		description:
+			'Proofread a WordPress post for grammar, spelling, punctuation, and style issues.',
+		buildMessages: (session) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -86,11 +70,9 @@ export function registerEditingPrompts(
 					description: 'Proofread a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to proofread a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to proofread a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -101,11 +83,9 @@ export function registerEditingPrompts(
 					description: 'Proofread a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to proofread a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to proofread a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -118,14 +98,11 @@ export function registerEditingPrompts(
 				description: `Proofread "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildProofreadContent(postContent),
-						},
+						role: 'user',
+						content: buildProofreadContent(postContent),
 					},
 				],
 			};
-		}
-	);
-}
+		},
+	},
+];

--- a/src/prompts/editing.ts
+++ b/src/prompts/editing.ts
@@ -15,7 +15,10 @@ export const editingPrompts: PromptDefinition[] = [
 					'A brief description of the editing focus or intent (e.g., "Make it more formal", "Improve the flow", "Condense the intro")'
 				),
 		},
-		buildMessages: (session, { editingFocus }) => {
+		buildMessages: (
+			session,
+			{ editingFocus }: { editingFocus: string }
+		) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {

--- a/src/prompts/pre-publish.ts
+++ b/src/prompts/pre-publish.ts
@@ -1,18 +1,12 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
 import { buildPrePublishCheckContent } from './prompt-content.js';
 
-export function registerPrePublishPrompts(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerPrompt(
-		'pre-publish-check',
-		{
-			description:
-				'Suggest metadata improvements before publishing — excerpt, categories, tags, and slug.',
-		},
-		() => {
+export const prePublishPrompts: PromptDefinition[] = [
+	{
+		name: 'pre-publish-check',
+		description:
+			'Suggest metadata improvements before publishing — excerpt, categories, tags, and slug.',
+		buildMessages: (session) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -20,11 +14,9 @@ export function registerPrePublishPrompts(
 					description: 'Pre-publish check',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to run a pre-publish check on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to run a pre-publish check on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -35,11 +27,9 @@ export function registerPrePublishPrompts(
 					description: 'Pre-publish check',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to run a pre-publish check on a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to run a pre-publish check on a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -52,14 +42,11 @@ export function registerPrePublishPrompts(
 				description: `Pre-publish check for "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildPrePublishCheckContent(postContent),
-						},
+						role: 'user',
+						content: buildPrePublishCheckContent(postContent),
 					},
 				],
 			};
-		}
-	);
-}
+		},
+	},
+];

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
+
+import { editingPrompts } from './editing.js';
+import { reviewPrompts } from './review.js';
+import { authoringPrompts } from './authoring.js';
+import { composePrompts } from './compose.js';
+import { prePublishPrompts } from './pre-publish.js';
+
+/** All prompt definitions, aggregated from every prompt file. */
+export const allPrompts: PromptDefinition[] = [
+	...editingPrompts,
+	...reviewPrompts,
+	...authoringPrompts,
+	...composePrompts,
+	...prePublishPrompts,
+];
+
+export function getPromptByName(name: string): PromptDefinition | undefined {
+	return allPrompts.find((p) => p.name === name);
+}
+
+/**
+ * Register a set of prompt definitions on an MCP server instance.
+ * Converts the simplified PromptMessage format to the MCP SDK's
+ * { type: 'text', text } content structure.
+ */
+export function registerPromptDefinitions(
+	server: McpServer,
+	session: SessionManager,
+	prompts: PromptDefinition[]
+): void {
+	for (const prompt of prompts) {
+		server.registerPrompt(
+			prompt.name,
+			{
+				description: prompt.description,
+				...(prompt.argsSchema ? { argsSchema: prompt.argsSchema } : {}),
+			},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic dispatch, validated by Zod
+			async (args: any) => {
+				const result = await prompt.buildMessages(
+					session,
+					args as Record<string, string>
+				);
+				return {
+					description: result.description,
+					messages: result.messages.map((m) => ({
+						role: m.role,
+						content: {
+							type: 'text' as const,
+							text: m.content,
+						},
+					})),
+				};
+			}
+		);
+	}
+}
+
+/**
+ * Register all prompts on an MCP server instance.
+ */
+export function registerAllPrompts(
+	server: McpServer,
+	session: SessionManager
+): void {
+	registerPromptDefinitions(server, session, allPrompts);
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -38,12 +38,8 @@ export function registerPromptDefinitions(
 				description: prompt.description,
 				...(prompt.argsSchema ? { argsSchema: prompt.argsSchema } : {}),
 			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic dispatch, validated by Zod
-			async (args: any) => {
-				const result = await prompt.buildMessages(
-					session,
-					args as Record<string, string>
-				);
+			async (args: Record<string, unknown>) => {
+				const result = await prompt.buildMessages(session, args);
 				return {
 					description: result.description,
 					messages: result.messages.map((m) => ({

--- a/src/prompts/review.ts
+++ b/src/prompts/review.ts
@@ -151,7 +151,7 @@ export const reviewPrompts: PromptDefinition[] = [
 				.positive()
 				.describe('The ID of the note to address.'),
 		},
-		buildMessages: async (session, { noteId }) => {
+		buildMessages: async (session, { noteId }: { noteId: number }) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -200,7 +200,7 @@ export const reviewPrompts: PromptDefinition[] = [
 			const { notes, noteBlockMap } = await session.listNotes();
 
 			// Find the target note and its replies
-			const targetNote = notes.find((n) => n.id === Number(noteId));
+			const targetNote = notes.find((n) => n.id === noteId);
 
 			if (!targetNote) {
 				return {
@@ -216,7 +216,7 @@ export const reviewPrompts: PromptDefinition[] = [
 
 			// Collect the target note and all descendants (not just
 			// direct children) so formatNotes can render the full thread.
-			const relevantIds = new Set<number>([Number(noteId)]);
+			const relevantIds = new Set<number>([noteId]);
 			let changed = true;
 			while (changed) {
 				changed = false;
@@ -229,9 +229,9 @@ export const reviewPrompts: PromptDefinition[] = [
 			}
 			const relevantNotes = notes.filter((n) => relevantIds.has(n.id));
 			const relevantMap: Partial<Record<number, string>> = {};
-			const blockIdx = noteBlockMap[Number(noteId)];
+			const blockIdx = noteBlockMap[noteId];
 			if (blockIdx !== undefined) {
-				relevantMap[Number(noteId)] = blockIdx;
+				relevantMap[noteId] = blockIdx;
 			}
 
 			const formattedNote = formatNotes(relevantNotes, relevantMap);

--- a/src/prompts/review.ts
+++ b/src/prompts/review.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { PromptDefinition } from './definitions.js';
 import {
 	formatNotes,
 	buildReviewContent,
@@ -8,17 +7,12 @@ import {
 	buildRespondToNoteContent,
 } from './prompt-content.js';
 
-export function registerReviewPrompts(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerPrompt(
-		'review',
-		{
-			description:
-				'Review a WordPress post and leave editorial feedback as notes on individual blocks.',
-		},
-		() => {
+export const reviewPrompts: PromptDefinition[] = [
+	{
+		name: 'review',
+		description:
+			'Review a WordPress post and leave editorial feedback as notes on individual blocks.',
+		buildMessages: (session) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -26,11 +20,9 @@ export function registerReviewPrompts(
 					description: 'Review a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to review a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to review a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -41,11 +33,9 @@ export function registerReviewPrompts(
 					description: 'Review a WordPress post',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to review a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to review a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -59,27 +49,21 @@ export function registerReviewPrompts(
 				description: `Review "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildReviewContent(
-								postContent,
-								notesSupported
-							),
-						},
+						role: 'user',
+						content: buildReviewContent(
+							postContent,
+							notesSupported
+						),
 					},
 				],
 			};
-		}
-	);
-
-	server.registerPrompt(
-		'respond-to-notes',
-		{
-			description:
-				'Address editorial notes on a WordPress post — read each note, make the requested changes, and resolve notes when done.',
 		},
-		async () => {
+	},
+	{
+		name: 'respond-to-notes',
+		description:
+			'Address editorial notes on a WordPress post — read each note, make the requested changes, and resolve notes when done.',
+		buildMessages: async (session) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -87,11 +71,9 @@ export function registerReviewPrompts(
 					description: 'Respond to editorial notes',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to respond to editorial notes on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to respond to editorial notes on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -102,11 +84,9 @@ export function registerReviewPrompts(
 					description: 'Respond to editorial notes',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to respond to editorial notes on a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to respond to editorial notes on a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -120,11 +100,9 @@ export function registerReviewPrompts(
 					description: 'Respond to editorial notes',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'This WordPress site does not support notes (requires WordPress 6.9+). There are no notes to respond to.',
-							},
+							role: 'user',
+							content:
+								'This WordPress site does not support notes (requires WordPress 6.9+). There are no notes to respond to.',
 						},
 					],
 				};
@@ -138,11 +116,9 @@ export function registerReviewPrompts(
 					description: 'Respond to editorial notes',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'There are no notes on this post. No action needed.',
-							},
+							role: 'user',
+							content:
+								'There are no notes on this post. No action needed.',
 						},
 					],
 				};
@@ -154,34 +130,28 @@ export function registerReviewPrompts(
 				description: `Respond to notes on "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildRespondToNotesContent(
-								postContent,
-								formattedNotes
-							),
-						},
+						role: 'user',
+						content: buildRespondToNotesContent(
+							postContent,
+							formattedNotes
+						),
 					},
 				],
 			};
-		}
-	);
-
-	server.registerPrompt(
-		'respond-to-note',
-		{
-			description:
-				'Address a single editorial note on a WordPress post — read it, make the requested changes, and resolve when done.',
-			argsSchema: {
-				noteId: z.coerce
-					.number()
-					.int()
-					.positive()
-					.describe('The ID of the note to address.'),
-			},
 		},
-		async ({ noteId }) => {
+	},
+	{
+		name: 'respond-to-note',
+		description:
+			'Address a single editorial note on a WordPress post — read it, make the requested changes, and resolve when done.',
+		argsSchema: {
+			noteId: z.coerce
+				.number()
+				.int()
+				.positive()
+				.describe('The ID of the note to address.'),
+		},
+		buildMessages: async (session, { noteId }) => {
 			const state = session.getState();
 
 			if (state === 'disconnected') {
@@ -189,11 +159,9 @@ export function registerReviewPrompts(
 					description: 'Respond to a note',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to respond to an editorial note on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
-							},
+							role: 'user',
+							content:
+								'I want to respond to an editorial note on a WordPress post. Please connect to WordPress first using wp_connect, then open a post with wp_open_post.',
 						},
 					],
 				};
@@ -204,11 +172,9 @@ export function registerReviewPrompts(
 					description: 'Respond to a note',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'I want to respond to an editorial note on a WordPress post. Please open a post with wp_open_post first.',
-							},
+							role: 'user',
+							content:
+								'I want to respond to an editorial note on a WordPress post. Please open a post with wp_open_post first.',
 						},
 					],
 				};
@@ -222,11 +188,9 @@ export function registerReviewPrompts(
 					description: 'Respond to a note',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: 'This WordPress site does not support notes (requires WordPress 6.9+). There are no notes to respond to.',
-							},
+							role: 'user',
+							content:
+								'This WordPress site does not support notes (requires WordPress 6.9+). There are no notes to respond to.',
 						},
 					],
 				};
@@ -236,18 +200,15 @@ export function registerReviewPrompts(
 			const { notes, noteBlockMap } = await session.listNotes();
 
 			// Find the target note and its replies
-			const targetNote = notes.find((n) => n.id === noteId);
+			const targetNote = notes.find((n) => n.id === Number(noteId));
 
 			if (!targetNote) {
 				return {
 					description: 'Respond to a note',
 					messages: [
 						{
-							role: 'user' as const,
-							content: {
-								type: 'text' as const,
-								text: `Note #${noteId} was not found on this post. It may have already been resolved. Use wp_list_notes to see current notes.`,
-							},
+							role: 'user',
+							content: `Note #${noteId} was not found on this post. It may have already been resolved. Use wp_list_notes to see current notes.`,
 						},
 					],
 				};
@@ -255,7 +216,7 @@ export function registerReviewPrompts(
 
 			// Collect the target note and all descendants (not just
 			// direct children) so formatNotes can render the full thread.
-			const relevantIds = new Set<number>([noteId]);
+			const relevantIds = new Set<number>([Number(noteId)]);
 			let changed = true;
 			while (changed) {
 				changed = false;
@@ -268,9 +229,9 @@ export function registerReviewPrompts(
 			}
 			const relevantNotes = notes.filter((n) => relevantIds.has(n.id));
 			const relevantMap: Partial<Record<number, string>> = {};
-			const blockIdx = noteBlockMap[noteId];
+			const blockIdx = noteBlockMap[Number(noteId)];
 			if (blockIdx !== undefined) {
-				relevantMap[noteId] = blockIdx;
+				relevantMap[Number(noteId)] = blockIdx;
 			}
 
 			const formattedNote = formatNotes(relevantNotes, relevantMap);
@@ -279,17 +240,14 @@ export function registerReviewPrompts(
 				description: `Respond to note #${noteId} on "${session.getTitle()}"`,
 				messages: [
 					{
-						role: 'user' as const,
-						content: {
-							type: 'text' as const,
-							text: buildRespondToNoteContent(
-								postContent,
-								formattedNote
-							),
-						},
+						role: 'user',
+						content: buildRespondToNoteContent(
+							postContent,
+							formattedNote
+						),
 					},
 				],
 			};
-		}
-	);
-}
+		},
+	},
+];

--- a/src/server-instructions.ts
+++ b/src/server-instructions.ts
@@ -1,0 +1,57 @@
+import { COMMANDS } from '../shared/commands.js';
+
+/**
+ * Base MCP server instructions, varying by auto-connect state.
+ */
+export function getBaseInstructions(autoConnected: boolean): string {
+	return autoConnected
+		? 'Already connected to WordPress. Do NOT call wp_connect. Use wp_status to check connection state, then wp_open_post or wp_create_post to start editing.'
+		: 'Use wp_connect to connect to a WordPress site first, or use wp_status to check connection state.';
+}
+
+/**
+ * Channel instructions for handling WordPress editor commands.
+ * Built from the shared COMMANDS definitions.
+ */
+export function getChannelInstructions(): string {
+	const promptDescriptions = Object.values(COMMANDS)
+		.map((cmd) => {
+			if (cmd.channelHint) {
+				return cmd.channelHint;
+			}
+			const argHints = Object.entries(cmd.args)
+				.map(([name]) => `arguments.${name}`)
+				.join(', ');
+			return argHints
+				? `"${cmd.slug}" (${cmd.description}, using ${argHints})`
+				: `"${cmd.slug}" (${cmd.description})`;
+		})
+		.join(', ');
+
+	return `
+
+When you receive a <channel source="wpce"> event, it contains a command from a user in the WordPress editor. Check the meta.event_type field:
+
+**Content-embedded command (meta.content_embedded = "true"):**
+The notification content contains the full post content and task instructions. The post is already open.
+1. If meta.status is "already_claimed", proceed directly to step 3.
+2. Otherwise, call wp_update_command_status with the command_id and status "running".
+3. Execute the task described in the notification content. Do NOT call wp_open_post or wp_read_post — the content is already embedded.
+4. Call wp_update_command_status with status "completed" and a brief summary, or "failed" with an error message.
+
+**New command (no event_type or event_type is absent, no content_embedded):**
+1. If meta.status is "already_claimed", skip this step. Otherwise, call wp_update_command_status with the command_id from the notification metadata and status "running".
+2. If no post is open, call wp_open_post with the post_id from the notification metadata. If a different post is open, call wp_close_post first.
+3. Execute the requested action based on the prompt field: ${promptDescriptions}.
+4. Call wp_update_command_status with status "completed" and a brief summary, or "failed" with an error message.
+
+**User response (event_type = "response"):**
+This is a reply to a question you asked via awaiting_input. The command is already in "running" status — do NOT call wp_update_command_status with "running" again. The meta.messages field contains the full conversation history. Resume processing the original command using the conversation context.
+
+**Asking the user a question (two-way communication):**
+To ask the user a follow-up question during command execution:
+1. Call wp_update_command_status with status "awaiting_input" and your question as the message. WordPress automatically tracks the conversation history, so resultData is optional. If you include resultData, use it only for non-message workflow flags (for example, state such as planReady) and do NOT duplicate conversation messages/history there.
+2. Format messages as simple HTML: use <p> tags for paragraphs, <strong> for emphasis, <ol>/<ul>/<li> for lists.
+3. Wait for a <channel source="wpce"> notification with event_type "response". Do not proceed until you receive it.
+4. The awaiting_input status does not expire — the user can take their time responding.`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,22 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { COMMANDS } from '../shared/commands.js';
 import { SessionManager } from './session/session-manager.js';
-import { registerConnectTools } from './tools/connect.js';
-import { registerPostTools } from './tools/posts.js';
-import { registerReadTools } from './tools/read.js';
-import { registerEditTools } from './tools/edit.js';
-import { registerStatusTools } from './tools/status.js';
-import { registerBlockTypeTools } from './tools/block-types.js';
-import { registerMediaTools } from './tools/media.js';
-import { registerNoteTools } from './tools/notes.js';
-import { registerMetadataTools } from './tools/metadata.js';
-import { registerCommandTools } from './tools/commands.js';
-import { registerEditingPrompts } from './prompts/editing.js';
-import { registerReviewPrompts } from './prompts/review.js';
-import { registerAuthoringPrompts } from './prompts/authoring.js';
-import { registerPrePublishPrompts } from './prompts/pre-publish.js';
-import { registerComposePrompts } from './prompts/compose.js';
+import { registerAllTools } from './tools/registry.js';
+import { registerAllPrompts } from './prompts/registry.js';
+import {
+	getBaseInstructions,
+	getChannelInstructions,
+} from './server-instructions.js';
 
 import { VERSION } from './version.js';
 export { VERSION };
@@ -40,54 +30,8 @@ export async function startServer(): Promise<void> {
 		}
 	}
 
-	// Set instructions based on whether auto-connect succeeded
-	const baseInstructions = autoConnected
-		? 'Already connected to WordPress. Do NOT call wp_connect. Use wp_status to check connection state, then wp_open_post or wp_create_post to start editing.'
-		: 'Use wp_connect to connect to a WordPress site first, or use wp_status to check connection state.';
-
-	// Build the prompt→action mapping for channel instructions from shared definitions
-	const promptDescriptions = Object.values(COMMANDS)
-		.map((cmd) => {
-			if (cmd.channelHint) {
-				return cmd.channelHint;
-			}
-			const argHints = Object.entries(cmd.args)
-				.map(([name]) => `arguments.${name}`)
-				.join(', ');
-			return argHints
-				? `"${cmd.slug}" (${cmd.description}, using ${argHints})`
-				: `"${cmd.slug}" (${cmd.description})`;
-		})
-		.join(', ');
-
-	const channelInstructions = `
-
-When you receive a <channel source="wpce"> event, it contains a command from a user in the WordPress editor. Check the meta.event_type field:
-
-**Content-embedded command (meta.content_embedded = "true"):**
-The notification content contains the full post content and task instructions. The post is already open.
-1. If meta.status is "already_claimed", proceed directly to step 3.
-2. Otherwise, call wp_update_command_status with the command_id and status "running".
-3. Execute the task described in the notification content. Do NOT call wp_open_post or wp_read_post — the content is already embedded.
-4. Call wp_update_command_status with status "completed" and a brief summary, or "failed" with an error message.
-
-**New command (no event_type or event_type is absent, no content_embedded):**
-1. If meta.status is "already_claimed", skip this step. Otherwise, call wp_update_command_status with the command_id from the notification metadata and status "running".
-2. If no post is open, call wp_open_post with the post_id from the notification metadata. If a different post is open, call wp_close_post first.
-3. Execute the requested action based on the prompt field: ${promptDescriptions}.
-4. Call wp_update_command_status with status "completed" and a brief summary, or "failed" with an error message.
-
-**User response (event_type = "response"):**
-This is a reply to a question you asked via awaiting_input. The command is already in "running" status — do NOT call wp_update_command_status with "running" again. The meta.messages field contains the full conversation history. Resume processing the original command using the conversation context.
-
-**Asking the user a question (two-way communication):**
-To ask the user a follow-up question during command execution:
-1. Call wp_update_command_status with status "awaiting_input" and your question as the message. WordPress automatically tracks the conversation history, so resultData is optional. If you include resultData, use it only for non-message workflow flags (for example, state such as planReady) and do NOT duplicate conversation messages/history there.
-2. Format messages as simple HTML: use <p> tags for paragraphs, <strong> for emphasis, <ol>/<ul>/<li> for lists.
-3. Wait for a <channel source="wpce"> notification with event_type "response". Do not proceed until you receive it.
-4. The awaiting_input status does not expire — the user can take their time responding.`;
-
-	const instructions = baseInstructions + channelInstructions;
+	const instructions =
+		getBaseInstructions(autoConnected) + getChannelInstructions();
 
 	const server = new McpServer(
 		{ name: 'wpce', version: VERSION },
@@ -99,17 +43,8 @@ To ask the user a follow-up question during command execution:
 		}
 	);
 
-	// Register all tools
-	registerConnectTools(server, session);
-	registerPostTools(server, session);
-	registerReadTools(server, session);
-	registerEditTools(server, session);
-	registerStatusTools(server, session);
-	registerBlockTypeTools(server, session);
-	registerMediaTools(server, session);
-	registerNoteTools(server, session);
-	registerMetadataTools(server, session);
-	registerCommandTools(server, session);
+	// Register all tools and prompts
+	registerAllTools(server, session);
 
 	// Wire up channel notifications from the command handler to the MCP client.
 	// Uses a type cast because notifications/claude/channel is experimental
@@ -122,11 +57,7 @@ To ask the user a follow-up question during command execution:
 	});
 
 	// Register all prompts
-	registerEditingPrompts(server, session);
-	registerReviewPrompts(server, session);
-	registerAuthoringPrompts(server, session);
-	registerPrePublishPrompts(server, session);
-	registerComposePrompts(server, session);
+	registerAllPrompts(server, session);
 
 	// Start stdio transport
 	const transport = new StdioServerTransport();

--- a/src/tools/block-types.ts
+++ b/src/tools/block-types.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
 import type { BlockTypeInfo } from '../yjs/block-type-registry.js';
+import type { ToolDefinition, ToolResult } from './definitions.js';
 
 /**
  * Format a single block type's info for display.
@@ -39,121 +38,69 @@ function formatBlockTypeInfo(info: BlockTypeInfo): string {
 	return lines.join('\n');
 }
 
-export function registerBlockTypeTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_block_types',
-		{
-			description:
-				'Look up block type schemas — attributes, defaults, nesting constraints. Use before inserting unfamiliar block types.',
-			inputSchema: {
-				name: z
-					.string()
-					.optional()
-					.describe(
-						'Exact block type name (e.g., "core/pullquote") for full details'
-					),
-				search: z
-					.string()
-					.optional()
-					.describe(
-						'Search block types by name (e.g., "quote", "media")'
-					),
-			},
+export const blockTypeTools: ToolDefinition[] = [
+	{
+		name: 'wp_block_types',
+		description:
+			'Look up block type schemas — attributes, defaults, nesting constraints. Use before inserting unfamiliar block types.',
+		inputSchema: {
+			name: z
+				.string()
+				.optional()
+				.describe(
+					'Exact block type name (e.g., "core/pullquote") for full details'
+				),
+			search: z
+				.string()
+				.optional()
+				.describe(
+					'Search block types by name (e.g., "quote", "media")'
+				),
 		},
-		({ name, search }) => {
-			try {
-				const registry = session.getRegistry();
+		execute: (
+			session,
+			{ name, search }: { name?: string; search?: string }
+		): string | ToolResult => {
+			const registry = session.getRegistry();
 
-				if (registry.isUsingFallback()) {
-					const state = session.getState();
-					const hint =
-						state === 'disconnected'
-							? 'Connect to a WordPress site to load full block schemas.'
-							: 'Full block schemas could not be loaded. Try disconnecting and reconnecting.';
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: `Block type registry is using fallback data. Only basic block type information is available. ${hint}`,
-							},
-						],
-					};
-				}
-
-				// Exact lookup by name
-				if (name) {
-					const info = registry.getBlockTypeInfo(name);
-					if (!info) {
-						return {
-							content: [
-								{
-									type: 'text' as const,
-									text: `Block type "${name}" not found. Use search to find block types.`,
-								},
-							],
-							isError: true,
-						};
-					}
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: formatBlockTypeInfo(info),
-							},
-						],
-					};
-				}
-
-				// Search by substring
-				if (search) {
-					const results = registry.searchBlockTypes(search);
-					if (results.length === 0) {
-						return {
-							content: [
-								{
-									type: 'text' as const,
-									text: `No block types matching "${search}".`,
-								},
-							],
-						};
-					}
-					const text = results
-						.map((r) => `${r.name} — ${r.title}`)
-						.join('\n');
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: `Found ${results.length} block type${results.length !== 1 ? 's' : ''}:\n${text}`,
-							},
-						],
-					};
-				}
-
-				// No arguments: list all block type names
-				const allNames = registry.getKnownBlockTypeNames();
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `${allNames.length} registered block types:\n${allNames.join('\n')}`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to look up block types: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+			if (registry.isUsingFallback()) {
+				const state = session.getState();
+				const hint =
+					state === 'disconnected'
+						? 'Connect to a WordPress site to load full block schemas.'
+						: 'Full block schemas could not be loaded. Try disconnecting and reconnecting.';
+				return `Block type registry is using fallback data. Only basic block type information is available. ${hint}`;
 			}
-		}
-	);
-}
+
+			// Exact lookup by name
+			if (name) {
+				const info = registry.getBlockTypeInfo(name);
+				if (!info) {
+					return {
+						text: `Block type "${name}" not found. Use search to find block types.`,
+						isError: true,
+					};
+				}
+				return formatBlockTypeInfo(info);
+			}
+
+			// Search by substring
+			if (search) {
+				const results = registry.searchBlockTypes(search);
+				if (results.length === 0) {
+					return `No block types matching "${search}".`;
+				}
+				const text = results
+					.map((r) => `${r.name} — ${r.title}`)
+					.join('\n');
+				return `Found ${results.length} block type${results.length !== 1 ? 's' : ''}:\n${text}`;
+			}
+
+			// No arguments: list all block type names
+			const allNames = registry.getKnownBlockTypeNames();
+			return `${allNames.length} registered block types:\n${allNames.join('\n')}`;
+		},
+		tags: ['block-types'],
+		availableIn: ['connected', 'editing'],
+	},
+];

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -1,56 +1,63 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
+import type { CommandStatus } from '../../shared/commands.js';
 
-export function registerCommandTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_update_command_status',
-		{
-			description:
-				'Update the status of a command received from the WordPress editor. Call this when starting, completing, or failing a command from a channel notification. For awaiting_input: send status and message, and do not send conversation history in resultData (WordPress manages conversation history automatically). Only optional flags such as {"planReady": true} should be sent in resultData when needed.',
-			inputSchema: {
-				commandId: z
-					.number()
-					.describe(
-						'The command ID from the channel notification metadata'
-					),
-				status: z
-					.enum(['running', 'completed', 'failed', 'awaiting_input'])
-					.describe('New status for the command'),
-				message: z
-					.string()
-					.optional()
-					.describe(
-						'Status message, error description, or question for the user. For awaiting_input: format as HTML (use <p> for paragraphs, <strong> for emphasis, <ol>/<ul>/<li> for lists, colons for labels).'
-					),
-				resultData: z
-					.string()
-					.optional()
-					.refine(
-						(val) => {
-							if (val === undefined) return true;
-							try {
-								const parsed: unknown = JSON.parse(val);
-								return (
-									typeof parsed === 'object' &&
-									parsed !== null &&
-									!Array.isArray(parsed)
-								);
-							} catch {
-								return false;
-							}
-						},
-						{ message: 'resultData must be a JSON object string' }
-					)
-					.describe(
-						'Optional JSON object string of structured result data. For awaiting_input: conversation messages are managed automatically — only send flags here (e.g., {"planReady": true} when the outline is ready for approval). The planReady flag adds an Approve button in the editor.'
-					),
-			},
+interface UpdateCommandStatusInput {
+	commandId: number;
+	status: CommandStatus;
+	message?: string;
+	resultData?: string;
+}
+
+export const commandTools: ToolDefinition[] = [
+	{
+		name: 'wp_update_command_status',
+		description:
+			'Update the status of a command received from the WordPress editor. Call this when starting, completing, or failing a command from a channel notification. For awaiting_input: send status and message, and do not send conversation history in resultData (WordPress manages conversation history automatically). Only optional flags such as {"planReady": true} should be sent in resultData when needed.',
+		inputSchema: {
+			commandId: z
+				.number()
+				.describe(
+					'The command ID from the channel notification metadata'
+				),
+			status: z
+				.enum(['running', 'completed', 'failed', 'awaiting_input'])
+				.describe('New status for the command'),
+			message: z
+				.string()
+				.optional()
+				.describe(
+					'Status message, error description, or question for the user. For awaiting_input: format as HTML (use <p> for paragraphs, <strong> for emphasis, <ol>/<ul>/<li> for lists, colons for labels).'
+				),
+			resultData: z
+				.string()
+				.optional()
+				.refine(
+					(val) => {
+						if (val === undefined) return true;
+						try {
+							const parsed: unknown = JSON.parse(val);
+							return (
+								typeof parsed === 'object' &&
+								parsed !== null &&
+								!Array.isArray(parsed)
+							);
+						} catch {
+							return false;
+						}
+					},
+					{ message: 'resultData must be a JSON object string' }
+				)
+				.describe(
+					'Optional JSON object string of structured result data. For awaiting_input: conversation messages are managed automatically — only send flags here (e.g., {"planReady": true} when the outline is ready for approval). The planReady flag adds an Approve button in the editor.'
+				),
 		},
-		async ({ commandId, status, message, resultData }) => {
+		availableIn: ['connected', 'editing'],
+		tags: ['commands'],
+		execute: async (
+			session,
+			{ commandId, status, message, resultData }: UpdateCommandStatusInput
+		) => {
 			// Strip CDATA wrappers that Claude Code may add to prevent
 			// HTML in the message from being parsed as XML.
 			const cleanMessage = message?.replace(
@@ -58,32 +65,13 @@ export function registerCommandTools(
 				'$1'
 			);
 
-			try {
-				await session.updateCommandStatus(
-					commandId,
-					status,
-					cleanMessage,
-					resultData
-				);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Command ${commandId} status updated to "${status}".`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to update command status: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-}
+			await session.updateCommandStatus(
+				commandId,
+				status,
+				cleanMessage,
+				resultData
+			);
+			return `Command ${commandId} status updated to "${status}".`;
+		},
+	},
+];

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod';
 import type { ToolDefinition } from './definitions.js';
-import type { CommandStatus } from '../../shared/commands.js';
+
+/** Statuses that can be set via the tool (subset of CommandStatus). */
+type SettableCommandStatus =
+	| 'running'
+	| 'completed'
+	| 'failed'
+	| 'awaiting_input';
 
 interface UpdateCommandStatusInput {
 	commandId: number;
-	status: CommandStatus;
+	status: SettableCommandStatus;
 	message?: string;
 	resultData?: string;
 }

--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -1,82 +1,52 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
 
-export function registerConnectTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_connect',
-		{
-			description:
-				'Connect to a WordPress site for collaborative editing. Not needed if the server was started with WP_SITE_URL, WP_USERNAME, and WP_APP_PASSWORD environment variables — check wp_status first.',
-			inputSchema: {
-				siteUrl: z
-					.string()
-					.describe('WordPress site URL (e.g., https://example.com)'),
-				username: z.string().describe('WordPress username'),
-				appPassword: z
-					.string()
-					.describe('WordPress Application Password'),
-			},
+interface ConnectInput {
+	siteUrl: string;
+	username: string;
+	appPassword: string;
+}
+
+export const connectTools: ToolDefinition[] = [
+	{
+		name: 'wp_connect',
+		description:
+			'Connect to a WordPress site for collaborative editing. Not needed if the server was started with WP_SITE_URL, WP_USERNAME, and WP_APP_PASSWORD environment variables — check wp_status first.',
+		inputSchema: {
+			siteUrl: z
+				.string()
+				.describe('WordPress site URL (e.g., https://example.com)'),
+			username: z.string().describe('WordPress username'),
+			appPassword: z.string().describe('WordPress Application Password'),
 		},
-		async ({ siteUrl, username, appPassword }) => {
+		availableIn: ['disconnected'],
+		tags: ['connection'],
+		execute: async (
+			session,
+			{ siteUrl, username, appPassword }: ConnectInput
+		) => {
 			const state = session.getState();
 			if (state !== 'disconnected') {
 				const user = session.getUser();
 				const userName = user?.name ?? 'unknown';
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Already connected as ${userName}. Use wp_disconnect first to reconnect to a different site.`,
-						},
-					],
-				};
+				return `Already connected as ${userName}. Use wp_disconnect first to reconnect to a different site.`;
 			}
-
-			try {
-				const user = await session.connect({
-					siteUrl,
-					username,
-					appPassword,
-				});
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Connected to ${siteUrl} as ${user.name ?? 'unknown'} (ID: ${user.id})`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Connection failed: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_disconnect',
-		{ description: 'Disconnect from the WordPress site' },
-		async () => {
+			const user = await session.connect({
+				siteUrl,
+				username,
+				appPassword,
+			});
+			return `Connected to ${siteUrl} as ${user.name ?? 'unknown'} (ID: ${user.id})`;
+		},
+	},
+	{
+		name: 'wp_disconnect',
+		description: 'Disconnect from the WordPress site',
+		availableIn: ['connected', 'editing'],
+		tags: ['connection'],
+		execute: async (session) => {
 			await session.disconnect();
-			return {
-				content: [
-					{
-						type: 'text' as const,
-						text: 'Disconnected from WordPress.',
-					},
-				],
-			};
-		}
-	);
-}
+			return 'Disconnected from WordPress.';
+		},
+	},
+];

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1,0 +1,56 @@
+import type { z } from 'zod';
+import type {
+	SessionManager,
+	SessionState,
+} from '../session/session-manager.js';
+
+/**
+ * Structured tool result for cases where `execute` needs to signal
+ * an error without throwing (e.g., expected-state checks, partial failures).
+ */
+export interface ToolResult {
+	text: string;
+	isError?: boolean;
+}
+
+/**
+ * Portable tool definition that can be consumed by both the MCP server
+ * (via registerToolDefinitions) and a hosted orchestrator (via the
+ * Anthropic API tool-use protocol).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional: input validated by Zod at runtime
+export interface ToolDefinition<TInput = any> {
+	/** Tool name (e.g., "wp_read_post") */
+	name: string;
+
+	/** Description shown to the model */
+	description: string;
+
+	/**
+	 * Optional Zod raw shape (record of Zod fields).
+	 * Omit for tools with no input parameters.
+	 * Matches the shape the MCP SDK's registerTool() expects.
+	 */
+	inputSchema?: z.ZodRawShape;
+
+	/**
+	 * Execute the tool.
+	 *
+	 * Return a string for a simple success message, or a ToolResult object
+	 * when you need to set isError without throwing (e.g., expected-state
+	 * checks, partial failures).
+	 *
+	 * Throw on unexpected errors — the caller (MCP wrapper or hosted
+	 * orchestrator) handles error formatting uniformly.
+	 */
+	execute: (
+		session: SessionManager,
+		input: TInput
+	) => Promise<string | ToolResult> | string | ToolResult;
+
+	/** Session states in which this tool is available (metadata only) */
+	availableIn?: SessionState[];
+
+	/** Tags for filtering (e.g., 'connection', 'editing', 'metadata') */
+	tags?: string[];
+}

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -56,7 +56,7 @@ interface EditBlockTextInput {
 const blockTypeDescription =
 	'Block type name (e.g., "core/paragraph", "core/heading", "core/separator")';
 
-const blockInputSchema: z.ZodType<BlockInput> = z.object({
+export const blockInputSchema: z.ZodType<BlockInput> = z.object({
 	name: z.string().describe(blockTypeDescription),
 	content: z.string().optional().describe('Text content for the block'),
 	attributes: z

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -1,6 +1,57 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager, BlockInput } from '../session/session-manager.js';
+import type { BlockInput } from '../session/session-manager.js';
+import type { ToolDefinition, ToolResult } from './definitions.js';
+
+interface UpdateBlockInput {
+	index: string;
+	content?: string;
+	attributes?: Record<string, unknown>;
+}
+
+interface InsertBlockInput {
+	position: number;
+	name: string;
+	content?: string;
+	attributes?: Record<string, unknown>;
+	innerBlocks?: BlockInput[];
+}
+
+interface InsertInnerBlockInput {
+	parentIndex: string;
+	position: number;
+	name: string;
+	content?: string;
+	attributes?: Record<string, unknown>;
+	innerBlocks?: BlockInput[];
+}
+
+interface RemoveBlocksInput {
+	startIndex: number;
+	count?: number;
+}
+
+interface RemoveInnerBlocksInput {
+	parentIndex: string;
+	startIndex: number;
+	count?: number;
+}
+
+interface MoveBlockInput {
+	fromIndex: number;
+	toIndex: number;
+}
+
+interface ReplaceBlocksInput {
+	startIndex: number;
+	count: number;
+	blocks: BlockInput[];
+}
+
+interface EditBlockTextInput {
+	index: string;
+	attribute?: string;
+	edits: Array<{ find: string; replace: string; occurrence?: number }>;
+}
 
 const blockTypeDescription =
 	'Block type name (e.g., "core/paragraph", "core/heading", "core/separator")';
@@ -18,461 +69,305 @@ const blockInputSchema: z.ZodType<BlockInput> = z.object({
 		.describe('Nested child blocks (e.g., list-items inside a list)'),
 });
 
-export function registerEditTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_update_block',
-		{
-			description: "Update a block's content and/or attributes",
-			inputSchema: {
-				index: z
-					.string()
-					.describe(
-						'Block index (e.g., "0", "2.1" for nested blocks)'
-					),
-				content: z
-					.string()
-					.optional()
-					.describe('New text content for the block'),
-				attributes: z
-					.record(z.string(), z.unknown())
-					.optional()
-					.describe('Attributes to update (key-value pairs)'),
-			},
+export const editTools: ToolDefinition[] = [
+	{
+		name: 'wp_update_block',
+		description: "Update a block's content and/or attributes",
+		inputSchema: {
+			index: z
+				.string()
+				.describe('Block index (e.g., "0", "2.1" for nested blocks)'),
+			content: z
+				.string()
+				.optional()
+				.describe('New text content for the block'),
+			attributes: z
+				.record(z.string(), z.unknown())
+				.optional()
+				.describe('Attributes to update (key-value pairs)'),
 		},
-		({ index, content, attributes }) => {
-			try {
-				session.updateBlock(index, { content, attributes });
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Updated block ${index}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to update block: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_insert_block',
-		{
-			description:
-				'Insert a new block at a position in the post. Supports nested blocks via innerBlocks.',
-			inputSchema: {
-				position: z
-					.number()
-					.describe('Position to insert the block (0-based index)'),
-				name: z.string().describe(blockTypeDescription),
-				content: z
-					.string()
-					.optional()
-					.describe('Text content for the block'),
-				attributes: z
-					.record(z.string(), z.unknown())
-					.optional()
-					.describe('Block attributes (key-value pairs)'),
-				innerBlocks: z
-					.array(blockInputSchema)
-					.optional()
-					.describe(
-						'Nested child blocks (e.g., list-items inside a list)'
-					),
-			},
+		execute: (
+			session,
+			{ index, content, attributes }: UpdateBlockInput
+		) => {
+			session.updateBlock(index, { content, attributes });
+			return `Updated block ${index}.`;
 		},
-		({ position, name, content, attributes, innerBlocks }) => {
-			try {
-				session.insertBlock(position, {
-					name,
-					content,
-					attributes,
-					innerBlocks,
-				});
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Inserted ${name} block at position ${position}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to insert block: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_insert_inner_block',
-		{
-			description:
-				'Insert a block as a child of an existing block (e.g., add a list-item to a list)',
-			inputSchema: {
-				parentIndex: z
-					.string()
-					.describe(
-						'Dot-notation index of the parent block (e.g., "0", "2.1")'
-					),
-				position: z
-					.number()
-					.describe(
-						"Position within the parent's inner blocks (0-based)"
-					),
-				name: z.string().describe(blockTypeDescription),
-				content: z
-					.string()
-					.optional()
-					.describe('Text content for the block'),
-				attributes: z
-					.record(z.string(), z.unknown())
-					.optional()
-					.describe('Block attributes (key-value pairs)'),
-				innerBlocks: z
-					.array(blockInputSchema)
-					.optional()
-					.describe('Nested child blocks'),
-			},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_insert_block',
+		description:
+			'Insert a new block at a position in the post. Supports nested blocks via innerBlocks.',
+		inputSchema: {
+			position: z
+				.number()
+				.describe('Position to insert the block (0-based index)'),
+			name: z.string().describe(blockTypeDescription),
+			content: z
+				.string()
+				.optional()
+				.describe('Text content for the block'),
+			attributes: z
+				.record(z.string(), z.unknown())
+				.optional()
+				.describe('Block attributes (key-value pairs)'),
+			innerBlocks: z
+				.array(blockInputSchema)
+				.optional()
+				.describe(
+					'Nested child blocks (e.g., list-items inside a list)'
+				),
 		},
-		({ parentIndex, position, name, content, attributes, innerBlocks }) => {
-			try {
-				session.insertInnerBlock(parentIndex, position, {
-					name,
-					content,
-					attributes,
-					innerBlocks,
-				});
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Inserted ${name} as inner block at ${parentIndex}.${position}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to insert inner block: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_remove_blocks',
-		{
-			description: 'Remove one or more blocks from the post',
-			inputSchema: {
-				startIndex: z
-					.number()
-					.describe('Index of the first block to remove'),
-				count: z
-					.number()
-					.optional()
-					.describe('Number of blocks to remove (default 1)'),
-			},
+		execute: (
+			session,
+			{
+				position,
+				name,
+				content,
+				attributes,
+				innerBlocks,
+			}: InsertBlockInput
+		) => {
+			session.insertBlock(position, {
+				name,
+				content,
+				attributes,
+				innerBlocks,
+			});
+			return `Inserted ${name} block at position ${position}.`;
 		},
-		({ startIndex, count }) => {
-			try {
-				const removeCount = count ?? 1;
-				session.removeBlocks(startIndex, removeCount);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Removed ${removeCount} block${removeCount !== 1 ? 's' : ''} starting at index ${startIndex}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to remove blocks: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_remove_inner_blocks',
-		{
-			description: 'Remove inner blocks from a parent block',
-			inputSchema: {
-				parentIndex: z
-					.string()
-					.describe(
-						'Dot-notation index of the parent block (e.g., "0")'
-					),
-				startIndex: z
-					.number()
-					.describe('Index of the first inner block to remove'),
-				count: z
-					.number()
-					.optional()
-					.describe('Number of inner blocks to remove (default 1)'),
-			},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_insert_inner_block',
+		description:
+			'Insert a block as a child of an existing block (e.g., add a list-item to a list)',
+		inputSchema: {
+			parentIndex: z
+				.string()
+				.describe(
+					'Dot-notation index of the parent block (e.g., "0", "2.1")'
+				),
+			position: z
+				.number()
+				.describe(
+					"Position within the parent's inner blocks (0-based)"
+				),
+			name: z.string().describe(blockTypeDescription),
+			content: z
+				.string()
+				.optional()
+				.describe('Text content for the block'),
+			attributes: z
+				.record(z.string(), z.unknown())
+				.optional()
+				.describe('Block attributes (key-value pairs)'),
+			innerBlocks: z
+				.array(blockInputSchema)
+				.optional()
+				.describe('Nested child blocks'),
 		},
-		({ parentIndex, startIndex, count }) => {
-			try {
-				const removeCount = count ?? 1;
-				session.removeInnerBlocks(parentIndex, startIndex, removeCount);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Removed ${removeCount} inner block${removeCount !== 1 ? 's' : ''} from block ${parentIndex}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to remove inner blocks: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_move_block',
-		{
-			description: 'Move a block from one position to another',
-			inputSchema: {
-				fromIndex: z.number().describe('Current position of the block'),
-				toIndex: z.number().describe('Target position for the block'),
-			},
+		execute: (
+			session,
+			{
+				parentIndex,
+				position,
+				name,
+				content,
+				attributes,
+				innerBlocks,
+			}: InsertInnerBlockInput
+		) => {
+			session.insertInnerBlock(parentIndex, position, {
+				name,
+				content,
+				attributes,
+				innerBlocks,
+			});
+			return `Inserted ${name} as inner block at ${parentIndex}.${position}.`;
 		},
-		({ fromIndex, toIndex }) => {
-			try {
-				session.moveBlock(fromIndex, toIndex);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Moved block from position ${fromIndex} to ${toIndex}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to move block: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_replace_blocks',
-		{
-			description:
-				'Replace a range of blocks with new blocks. Supports nested blocks via innerBlocks.',
-			inputSchema: {
-				startIndex: z
-					.number()
-					.describe('Index of the first block to replace'),
-				count: z.number().describe('Number of blocks to replace'),
-				blocks: z
-					.array(blockInputSchema)
-					.describe(
-						'New blocks to insert in place of the removed ones'
-					),
-			},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_remove_blocks',
+		description: 'Remove one or more blocks from the post',
+		inputSchema: {
+			startIndex: z
+				.number()
+				.describe('Index of the first block to remove'),
+			count: z
+				.number()
+				.optional()
+				.describe('Number of blocks to remove (default 1)'),
 		},
-		({ startIndex, count, blocks }) => {
-			try {
-				session.replaceBlocks(startIndex, count, blocks);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Replaced ${count} block${count !== 1 ? 's' : ''} at index ${startIndex} with ${blocks.length} new block${blocks.length !== 1 ? 's' : ''}.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to replace blocks: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_edit_block_text',
-		{
-			description:
-				'Make surgical find-and-replace text edits within a block. ' +
-				'More efficient than wp_update_block for small corrections (typos, ' +
-				'grammar fixes) — only the targeted text is changed, preserving concurrent edits.',
-			inputSchema: {
-				index: z
-					.string()
-					.describe(
-						'Block index (e.g., "0", "2.1" for nested blocks)'
-					),
-				attribute: z
-					.string()
-					.optional()
-					.describe(
-						'Rich-text attribute to edit (default: "content"). ' +
-							'Use "citation" for quote/pullquote citations, "value" for pullquote text, etc.'
-					),
-				edits: z
-					.array(
-						z.object({
-							find: z
-								.string()
-								.min(1)
-								.describe(
-									'Exact text to find in the current content (may include HTML tags like <strong>, <a href="...">)'
-								),
-							replace: z
-								.string()
-								.describe(
-									'Replacement text (empty string to delete the found text)'
-								),
-							occurrence: z
-								.number()
-								.int()
-								.min(1)
-								.optional()
-								.describe(
-									'Which occurrence to replace (1-indexed, default 1). Use when the same text appears multiple times.'
-								),
-						})
-					)
-					.min(1)
-					.describe(
-						'List of find-and-replace operations applied sequentially'
-					),
-			},
+		execute: (session, { startIndex, count }: RemoveBlocksInput) => {
+			const removeCount = count ?? 1;
+			session.removeBlocks(startIndex, removeCount);
+			return `Removed ${removeCount} block${removeCount !== 1 ? 's' : ''} starting at index ${startIndex}.`;
 		},
-		({ index, attribute, edits }) => {
-			try {
-				const result = session.editBlockText(index, edits, attribute);
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_remove_inner_blocks',
+		description: 'Remove inner blocks from a parent block',
+		inputSchema: {
+			parentIndex: z
+				.string()
+				.describe('Dot-notation index of the parent block (e.g., "0")'),
+			startIndex: z
+				.number()
+				.describe('Index of the first inner block to remove'),
+			count: z
+				.number()
+				.optional()
+				.describe('Number of inner blocks to remove (default 1)'),
+		},
+		execute: (
+			session,
+			{ parentIndex, startIndex, count }: RemoveInnerBlocksInput
+		) => {
+			const removeCount = count ?? 1;
+			session.removeInnerBlocks(parentIndex, startIndex, removeCount);
+			return `Removed ${removeCount} inner block${removeCount !== 1 ? 's' : ''} from block ${parentIndex}.`;
+		},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_move_block',
+		description: 'Move a block from one position to another',
+		inputSchema: {
+			fromIndex: z.number().describe('Current position of the block'),
+			toIndex: z.number().describe('Target position for the block'),
+		},
+		execute: (session, { fromIndex, toIndex }: MoveBlockInput) => {
+			session.moveBlock(fromIndex, toIndex);
+			return `Moved block from position ${fromIndex} to ${toIndex}.`;
+		},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_replace_blocks',
+		description:
+			'Replace a range of blocks with new blocks. Supports nested blocks via innerBlocks.',
+		inputSchema: {
+			startIndex: z
+				.number()
+				.describe('Index of the first block to replace'),
+			count: z.number().describe('Number of blocks to replace'),
+			blocks: z
+				.array(blockInputSchema)
+				.describe('New blocks to insert in place of the removed ones'),
+		},
+		execute: (
+			session,
+			{ startIndex, count, blocks }: ReplaceBlocksInput
+		) => {
+			session.replaceBlocks(startIndex, count, blocks);
+			return `Replaced ${count} block${count !== 1 ? 's' : ''} at index ${startIndex} with ${blocks.length} new block${blocks.length !== 1 ? 's' : ''}.`;
+		},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_edit_block_text',
+		description:
+			'Make surgical find-and-replace text edits within a block. ' +
+			'More efficient than wp_update_block for small corrections (typos, ' +
+			'grammar fixes) — only the targeted text is changed, preserving concurrent edits.',
+		inputSchema: {
+			index: z
+				.string()
+				.describe('Block index (e.g., "0", "2.1" for nested blocks)'),
+			attribute: z
+				.string()
+				.optional()
+				.describe(
+					'Rich-text attribute to edit (default: "content"). ' +
+						'Use "citation" for quote/pullquote citations, "value" for pullquote text, etc.'
+				),
+			edits: z
+				.array(
+					z.object({
+						find: z
+							.string()
+							.min(1)
+							.describe(
+								'Exact text to find in the current content (may include HTML tags like <strong>, <a href="...">)'
+							),
+						replace: z
+							.string()
+							.describe(
+								'Replacement text (empty string to delete the found text)'
+							),
+						occurrence: z
+							.number()
+							.int()
+							.min(1)
+							.optional()
+							.describe(
+								'Which occurrence to replace (1-indexed, default 1). Use when the same text appears multiple times.'
+							),
+					})
+				)
+				.min(1)
+				.describe(
+					'List of find-and-replace operations applied sequentially'
+				),
+		},
+		execute: (
+			session,
+			{ index, attribute, edits }: EditBlockTextInput
+		): ToolResult => {
+			const result = session.editBlockText(index, edits, attribute);
 
-				const lines: string[] = [];
-				if (result.failedCount > 0) {
-					lines.push(
-						`Applied ${result.appliedCount}/${result.edits.length} edit${result.edits.length !== 1 ? 's' : ''}.`
-					);
-					for (const edit of result.edits) {
-						if (!edit.applied) {
-							lines.push(
-								`  FAILED: find "${edit.find}" — ${edit.error}`
-							);
-						}
+			const lines: string[] = [];
+			if (result.failedCount > 0) {
+				lines.push(
+					`Applied ${result.appliedCount}/${result.edits.length} edit${result.edits.length !== 1 ? 's' : ''}.`
+				);
+				for (const edit of result.edits) {
+					if (!edit.applied) {
+						lines.push(
+							`  FAILED: find "${edit.find}" — ${edit.error}`
+						);
 					}
-				} else {
-					lines.push(
-						`Applied ${result.appliedCount} edit${result.appliedCount !== 1 ? 's' : ''}.`
-					);
 				}
-
-				// Include the updated block rendering for verification
-				const updated = session.readBlock(index);
-				lines.push('');
-				lines.push(updated);
-
-				return {
-					content: [
-						{ type: 'text' as const, text: lines.join('\n') },
-					],
-					isError:
-						result.appliedCount === 0 && result.failedCount > 0,
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to edit block text: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+			} else {
+				lines.push(
+					`Applied ${result.appliedCount} edit${result.appliedCount !== 1 ? 's' : ''}.`
+				);
 			}
-		}
-	);
 
-	server.registerTool(
-		'wp_set_title',
-		{
-			description: 'Set the post title',
-			inputSchema: {
-				title: z.string().describe('New post title'),
-			},
+			const updated = session.readBlock(index);
+			lines.push('');
+			lines.push(updated);
+
+			return {
+				text: lines.join('\n'),
+				isError: result.appliedCount === 0 && result.failedCount > 0,
+			};
 		},
-		({ title }) => {
-			try {
-				session.setTitle(title);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Title set to "${title}".`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set title: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-}
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_title',
+		description: 'Set the post title',
+		inputSchema: {
+			title: z.string().describe('New post title'),
+		},
+		execute: (session, { title }: { title: string }) => {
+			session.setTitle(title);
+			return `Title set to "${title}".`;
+		},
+		tags: ['editing'],
+		availableIn: ['editing'],
+	},
+];

--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
 import { getMediaCategory } from '../wordpress/mime-types.js';
 import type { WPMediaItem } from '../wordpress/types.js';
+
+interface UploadMediaInput {
+	filePath: string;
+	altText?: string;
+	title?: string;
+	caption?: string;
+}
 
 /**
  * Build a block insertion hint based on the uploaded media's MIME type.
@@ -55,79 +61,60 @@ function buildInsertionHint(media: WPMediaItem): string {
 	return lines.join('\n');
 }
 
-export function registerMediaTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_upload_media',
-		{
-			description:
-				'Upload a local file to the WordPress media library. Returns the attachment ID and URL for use with wp_insert_block (e.g., core/image, core/video, core/audio, core/file).',
-			inputSchema: {
-				filePath: z
-					.string()
-					.describe('Absolute path to the local file to upload'),
-				altText: z
-					.string()
-					.optional()
-					.describe(
-						'Alt text for the media (important for image accessibility)'
-					),
-				title: z
-					.string()
-					.optional()
-					.describe('Title for the media item'),
-				caption: z
-					.string()
-					.optional()
-					.describe('Caption for the media item'),
-			},
+export const mediaTools: ToolDefinition[] = [
+	{
+		name: 'wp_upload_media',
+		description:
+			'Upload a local file to the WordPress media library. Returns the attachment ID and URL for use with wp_insert_block (e.g., core/image, core/video, core/audio, core/file).',
+		inputSchema: {
+			filePath: z
+				.string()
+				.describe('Absolute path to the local file to upload'),
+			altText: z
+				.string()
+				.optional()
+				.describe(
+					'Alt text for the media (important for image accessibility)'
+				),
+			title: z.string().optional().describe('Title for the media item'),
+			caption: z
+				.string()
+				.optional()
+				.describe('Caption for the media item'),
 		},
-		async ({ filePath, altText, title, caption }) => {
-			try {
-				const media = await session.uploadMedia(filePath, {
-					altText,
-					title,
-					caption,
-				});
-				const lines = [
-					'Uploaded successfully.',
-					'',
-					`Attachment ID: ${media.id}`,
-					`URL: ${media.source_url}`,
-					`MIME type: ${media.mime_type}`,
-				];
+		availableIn: ['connected', 'editing'],
+		tags: ['media'],
+		execute: async (
+			session,
+			{ filePath, altText, title, caption }: UploadMediaInput
+		) => {
+			const media = await session.uploadMedia(filePath, {
+				altText,
+				title,
+				caption,
+			});
+			const lines = [
+				'Uploaded successfully.',
+				'',
+				`Attachment ID: ${media.id}`,
+				`URL: ${media.source_url}`,
+				`MIME type: ${media.mime_type}`,
+			];
 
-				if (media.alt_text) {
-					lines.push(`Alt text: ${media.alt_text}`);
-				}
-
-				if (media.media_details.width && media.media_details.height) {
-					lines.push(
-						`Dimensions: ${media.media_details.width}x${media.media_details.height}`
-					);
-				}
-
-				lines.push('');
-				lines.push(buildInsertionHint(media));
-
-				return {
-					content: [
-						{ type: 'text' as const, text: lines.join('\n') },
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to upload media: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+			if (media.alt_text) {
+				lines.push(`Alt text: ${media.alt_text}`);
 			}
-		}
-	);
-}
+
+			if (media.media_details.width && media.media_details.height) {
+				lines.push(
+					`Dimensions: ${media.media_details.width}x${media.media_details.height}`
+				);
+			}
+
+			lines.push('');
+			lines.push(buildInsertionHint(media));
+
+			return lines.join('\n');
+		},
+	},
+];

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -1,6 +1,33 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
+
+interface SetStatusInput {
+	status: string;
+}
+interface SetCategoriesInput {
+	categories: string[];
+}
+interface SetTagsInput {
+	tags: string[];
+}
+interface SetExcerptInput {
+	excerpt: string;
+}
+interface SetFeaturedImageInput {
+	attachmentId: number;
+}
+interface SetDateInput {
+	date: string;
+}
+interface SetSlugInput {
+	slug: string;
+}
+interface SetStickyInput {
+	sticky: boolean;
+}
+interface SetCommentStatusInput {
+	status: string;
+}
 
 const validStatuses = [
 	'draft',
@@ -24,457 +51,200 @@ function formatTermList(
 		.join('\n');
 }
 
-export function registerMetadataTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_list_categories',
-		{
-			description:
-				'List existing categories on the WordPress site. Use this before wp_set_categories to find appropriate existing categories.',
-			inputSchema: {
-				search: z
-					.string()
-					.optional()
-					.describe('Filter categories by name'),
-			},
+export const metadataTools: ToolDefinition[] = [
+	{
+		name: 'wp_list_categories',
+		description:
+			'List existing categories on the WordPress site. Use this before wp_set_categories to find appropriate existing categories.',
+		inputSchema: {
+			search: z.string().optional().describe('Filter categories by name'),
 		},
-		async ({ search }) => {
-			try {
-				const terms = await session.listCategories({ search });
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Categories:\n${formatTermList(terms)}`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to list categories: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_list_tags',
-		{
-			description:
-				'List existing tags on the WordPress site. Use this before wp_set_tags to find appropriate existing tags.',
-			inputSchema: {
-				search: z.string().optional().describe('Filter tags by name'),
-			},
+		execute: async (session, { search }: { search?: string }) => {
+			const terms = await session.listCategories({ search });
+			return `Categories:\n${formatTermList(terms)}`;
 		},
-		async ({ search }) => {
-			try {
-				const terms = await session.listTags({ search });
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Tags:\n${formatTermList(terms)}`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to list tags: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_status',
-		{
-			description:
-				'Change the post publication status. Use "future" with wp_set_date to schedule a post.',
-			inputSchema: {
-				status: z.enum(validStatuses).describe('New post status'),
-			},
+		tags: ['metadata'],
+		availableIn: ['connected', 'editing'],
+	},
+	{
+		name: 'wp_list_tags',
+		description:
+			'List existing tags on the WordPress site. Use this before wp_set_tags to find appropriate existing tags.',
+		inputSchema: {
+			search: z.string().optional().describe('Filter tags by name'),
 		},
-		async ({ status }) => {
-			try {
-				const oldStatus = session.getCurrentPost()?.status ?? 'unknown';
-				await session.setPostStatus(status);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Status changed from "${oldStatus}" to "${status}".`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set status: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_categories',
-		{
-			description:
-				"Set the post categories by name (replaces all existing categories). Creates categories that don't exist yet. WordPress requires at least one category.",
-			inputSchema: {
-				categories: z
-					.array(z.string())
-					.min(1)
-					.describe(
-						'Category names to assign (e.g., ["Tech", "News"])'
-					),
-			},
+		execute: async (session, { search }: { search?: string }) => {
+			const terms = await session.listTags({ search });
+			return `Tags:\n${formatTermList(terms)}`;
 		},
-		async ({ categories }) => {
-			try {
-				const { resolved } = await session.setCategories(categories);
-				const parts = resolved.map((r) =>
-					r.created ? `${r.name} (created)` : r.name
-				);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Categories set: ${parts.join(', ')}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set categories: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_tags',
-		{
-			description:
-				"Set the post tags by name (replaces all existing tags). Creates tags that don't exist yet. Pass an empty array to remove all tags.",
-			inputSchema: {
-				tags: z
-					.array(z.string())
-					.describe(
-						'Tag names to assign (e.g., ["tutorial", "beginner"])'
-					),
-			},
+		tags: ['metadata'],
+		availableIn: ['connected', 'editing'],
+	},
+	{
+		name: 'wp_set_status',
+		description:
+			'Change the post publication status. Use "future" with wp_set_date to schedule a post.',
+		inputSchema: {
+			status: z.enum(validStatuses).describe('New post status'),
 		},
-		async ({ tags }) => {
-			try {
-				if (tags.length === 0) {
-					await session.setTags([]);
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: 'All tags removed.',
-							},
-						],
-					};
-				}
-				const { resolved } = await session.setTags(tags);
-				const parts = resolved.map((r) =>
-					r.created ? `${r.name} (created)` : r.name
-				);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Tags set: ${parts.join(', ')}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set tags: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_excerpt',
-		{
-			description:
-				'Set the post excerpt (short summary shown in feeds and search results). Pass an empty string to clear.',
-			inputSchema: {
-				excerpt: z.string().describe('Post excerpt text'),
-			},
+		execute: async (session, { status }: SetStatusInput) => {
+			const oldStatus = session.getCurrentPost()?.status ?? 'unknown';
+			await session.setPostStatus(status);
+			return `Status changed from "${oldStatus}" to "${status}".`;
 		},
-		async ({ excerpt }) => {
-			try {
-				await session.setExcerpt(excerpt);
-				if (!excerpt) {
-					return {
-						content: [
-							{ type: 'text' as const, text: 'Excerpt cleared.' },
-						],
-					};
-				}
-				return {
-					content: [{ type: 'text' as const, text: `Excerpt set.` }],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set excerpt: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_featured_image',
-		{
-			description:
-				'Set the post featured image by media attachment ID. Use wp_upload_media first to upload an image and get its ID. Pass 0 to remove the featured image.',
-			inputSchema: {
-				attachmentId: z
-					.number()
-					.describe(
-						'Media attachment ID (from wp_upload_media), or 0 to remove'
-					),
-			},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_categories',
+		description:
+			"Set the post categories by name (replaces all existing categories). Creates categories that don't exist yet. WordPress requires at least one category.",
+		inputSchema: {
+			categories: z
+				.array(z.string())
+				.min(1)
+				.describe('Category names to assign (e.g., ["Tech", "News"])'),
 		},
-		async ({ attachmentId }) => {
-			try {
-				await session.setFeaturedImage(attachmentId);
-				if (attachmentId === 0) {
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: 'Featured image removed.',
-							},
-						],
-					};
-				}
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Featured image set to attachment ${attachmentId}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set featured image: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_date',
-		{
-			description:
-				'Set the post publication date. Use with wp_set_status("future") to schedule a post. Pass an empty string to reset to the current date.',
-			inputSchema: {
-				date: z
-					.string()
-					.describe(
-						'Publication date in ISO 8601 format (e.g., "2026-04-01T09:00:00"), or empty string to clear'
-					),
-			},
+		execute: async (session, { categories }: SetCategoriesInput) => {
+			const { resolved } = await session.setCategories(categories);
+			const parts = resolved.map((r) =>
+				r.created ? `${r.name} (created)` : r.name
+			);
+			return `Categories set: ${parts.join(', ')}.`;
 		},
-		async ({ date }) => {
-			try {
-				const updated = await session.setDate(date);
-				if (!date) {
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: 'Publication date reset to default.',
-							},
-						],
-					};
-				}
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Publication date set to ${updated.date}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set date: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_slug',
-		{
-			description:
-				'Set the post URL slug. WordPress may auto-modify the slug to ensure uniqueness.',
-			inputSchema: {
-				slug: z.string().describe('URL slug (e.g., "my-custom-url")'),
-			},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_tags',
+		description:
+			"Set the post tags by name (replaces all existing tags). Creates tags that don't exist yet. Pass an empty array to remove all tags.",
+		inputSchema: {
+			tags: z
+				.array(z.string())
+				.describe(
+					'Tag names to assign (e.g., ["tutorial", "beginner"])'
+				),
 		},
-		async ({ slug }) => {
-			try {
-				const updated = await session.setSlug(slug);
-				const actualSlug = updated.slug;
-				if (actualSlug !== slug) {
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: `Slug set to "${actualSlug}" (adjusted from "${slug}" for uniqueness).`,
-							},
-						],
-					};
-				}
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Slug set to "${actualSlug}".`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set slug: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
+		execute: async (session, { tags }: SetTagsInput) => {
+			if (tags.length === 0) {
+				await session.setTags([]);
+				return 'All tags removed.';
 			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_sticky',
-		{
-			description: 'Pin or unpin the post on the front page.',
-			inputSchema: {
-				sticky: z.boolean().describe('true to pin, false to unpin'),
-			},
+			const { resolved } = await session.setTags(tags);
+			const parts = resolved.map((r) =>
+				r.created ? `${r.name} (created)` : r.name
+			);
+			return `Tags set: ${parts.join(', ')}.`;
 		},
-		async ({ sticky }) => {
-			try {
-				await session.setSticky(sticky);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: sticky
-								? 'Post pinned to front page.'
-								: 'Post unpinned.',
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set sticky: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_set_comment_status',
-		{
-			description: 'Enable or disable comments on the post.',
-			inputSchema: {
-				status: z
-					.enum(['open', 'closed'])
-					.describe('"open" to enable comments, "closed" to disable'),
-			},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_excerpt',
+		description:
+			'Set the post excerpt (short summary shown in feeds and search results). Pass an empty string to clear.',
+		inputSchema: {
+			excerpt: z.string().describe('Post excerpt text'),
 		},
-		async ({ status }) => {
-			try {
-				await session.setCommentStatus(status);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text:
-								status === 'open'
-									? 'Comments enabled.'
-									: 'Comments disabled.',
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to set comment status: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
+		execute: async (session, { excerpt }: SetExcerptInput) => {
+			await session.setExcerpt(excerpt);
+			if (!excerpt) {
+				return 'Excerpt cleared.';
 			}
-		}
-	);
-}
+			return 'Excerpt set.';
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_featured_image',
+		description:
+			'Set the post featured image by media attachment ID. Use wp_upload_media first to upload an image and get its ID. Pass 0 to remove the featured image.',
+		inputSchema: {
+			attachmentId: z
+				.number()
+				.describe(
+					'Media attachment ID (from wp_upload_media), or 0 to remove'
+				),
+		},
+		execute: async (session, { attachmentId }: SetFeaturedImageInput) => {
+			await session.setFeaturedImage(attachmentId);
+			if (attachmentId === 0) {
+				return 'Featured image removed.';
+			}
+			return `Featured image set to attachment ${attachmentId}.`;
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_date',
+		description:
+			'Set the post publication date. Use with wp_set_status("future") to schedule a post. Pass an empty string to reset to the current date.',
+		inputSchema: {
+			date: z
+				.string()
+				.describe(
+					'Publication date in ISO 8601 format (e.g., "2026-04-01T09:00:00"), or empty string to clear'
+				),
+		},
+		execute: async (session, { date }: SetDateInput) => {
+			const updated = await session.setDate(date);
+			if (!date) {
+				return 'Publication date reset to default.';
+			}
+			return `Publication date set to ${updated.date}.`;
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_slug',
+		description:
+			'Set the post URL slug. WordPress may auto-modify the slug to ensure uniqueness.',
+		inputSchema: {
+			slug: z.string().describe('URL slug (e.g., "my-custom-url")'),
+		},
+		execute: async (session, { slug }: SetSlugInput) => {
+			const updated = await session.setSlug(slug);
+			const actualSlug = updated.slug;
+			if (actualSlug !== slug) {
+				return `Slug set to "${actualSlug}" (adjusted from "${slug}" for uniqueness).`;
+			}
+			return `Slug set to "${actualSlug}".`;
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_sticky',
+		description: 'Pin or unpin the post on the front page.',
+		inputSchema: {
+			sticky: z.boolean().describe('true to pin, false to unpin'),
+		},
+		execute: async (session, { sticky }: SetStickyInput) => {
+			await session.setSticky(sticky);
+			return sticky ? 'Post pinned to front page.' : 'Post unpinned.';
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_set_comment_status',
+		description: 'Enable or disable comments on the post.',
+		inputSchema: {
+			status: z
+				.enum(['open', 'closed'])
+				.describe('"open" to enable comments, "closed" to disable'),
+		},
+		execute: async (session, { status }: SetCommentStatusInput) => {
+			await session.setCommentStatus(status);
+			return status === 'open'
+				? 'Comments enabled.'
+				: 'Comments disabled.';
+		},
+		tags: ['metadata'],
+		availableIn: ['editing'],
+	},
+];

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,235 +1,130 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
 
-export function registerNoteTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_list_notes',
-		{
-			description:
-				'List all notes (block comments) on the currently open post. Returns note content, author, date, and which block each note is attached to. Replies are nested under their parent notes.',
-		},
-		async () => {
-			try {
-				const { notes, noteBlockMap } = await session.listNotes();
-				if (notes.length === 0) {
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: 'No notes on this post.',
-							},
-						],
-					};
+export const noteTools: ToolDefinition[] = [
+	{
+		name: 'wp_list_notes',
+		description:
+			'List all notes (block comments) on the currently open post. Returns note content, author, date, and which block each note is attached to. Replies are nested under their parent notes.',
+		execute: async (session) => {
+			const { notes, noteBlockMap } = await session.listNotes();
+			if (notes.length === 0) {
+				return 'No notes on this post.';
+			}
+			// Group: top-level notes (parent === 0) and replies (nested at any depth)
+			const topLevel = notes.filter((n) => n.parent === 0);
+			const replyMap = new Map<number, typeof notes>();
+			for (const note of notes) {
+				if (note.parent !== 0) {
+					const list = replyMap.get(note.parent) ?? [];
+					list.push(note);
+					replyMap.set(note.parent, list);
 				}
-				// Group: top-level notes (parent === 0) and replies (nested at any depth)
-				const topLevel = notes.filter((n) => n.parent === 0);
-				const replyMap = new Map<number, typeof notes>();
-				for (const note of notes) {
-					if (note.parent !== 0) {
-						const list = replyMap.get(note.parent) ?? [];
-						list.push(note);
-						replyMap.set(note.parent, list);
-					}
-				}
+			}
 
-				const lines: string[] = [];
-				const stripHtml = (html: string) =>
-					html.replace(/<[^>]*>/g, '');
-				const renderReplies = (parentId: number, depth: number) => {
-					const replies = replyMap.get(parentId) ?? [];
-					const indent = '  '.repeat(depth);
-					for (const reply of replies) {
-						lines.push(
-							`${indent}Reply #${reply.id} by ${reply.author_name} — ${reply.date}`
-						);
-						const replyContent =
-							reply.content.raw ??
-							stripHtml(reply.content.rendered);
-						lines.push(`${indent}  "${replyContent}"`);
-						renderReplies(reply.id, depth + 1);
-					}
-				};
-
-				for (const note of topLevel) {
-					const blockIdx = noteBlockMap[note.id];
-					const blockInfo =
-						blockIdx !== undefined
-							? ` (block [${blockIdx}])`
-							: ' (unlinked)';
+			const lines: string[] = [];
+			const stripHtml = (html: string) => html.replace(/<[^>]*>/g, '');
+			const renderReplies = (parentId: number, depth: number) => {
+				const replies = replyMap.get(parentId) ?? [];
+				const indent = '  '.repeat(depth);
+				for (const reply of replies) {
 					lines.push(
-						`Note #${note.id} by ${note.author_name}${blockInfo} — ${note.date}`
+						`${indent}Reply #${reply.id} by ${reply.author_name} — ${reply.date}`
 					);
-					const rawContent =
-						note.content.raw ?? stripHtml(note.content.rendered);
-					lines.push(`  "${rawContent}"`);
-					renderReplies(note.id, 1);
-					lines.push('');
+					const replyContent =
+						reply.content.raw ?? stripHtml(reply.content.rendered);
+					lines.push(`${indent}  "${replyContent}"`);
+					renderReplies(reply.id, depth + 1);
 				}
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: lines.join('\n').trim(),
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to list notes: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
+			};
 
-	server.registerTool(
-		'wp_add_note',
-		{
-			description:
-				'Add a note (block comment) to a specific block. Notes are editorial feedback visible in the WordPress editor but not shown to site visitors.',
-			inputSchema: {
-				blockIndex: z
-					.string()
-					.describe(
-						'Block index (e.g. "0", "2.1" for nested blocks)'
-					),
-				content: z.string().describe('Note text'),
-			},
-		},
-		async ({ blockIndex, content }) => {
-			try {
-				const note = await session.addNote(blockIndex, content);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Added note #${note.id} to block [${blockIndex}].`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to add note: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
+			for (const note of topLevel) {
+				const blockIdx = noteBlockMap[note.id];
+				const blockInfo =
+					blockIdx !== undefined
+						? ` (block [${blockIdx}])`
+						: ' (unlinked)';
+				lines.push(
+					`Note #${note.id} by ${note.author_name}${blockInfo} — ${note.date}`
+				);
+				const rawContent =
+					note.content.raw ?? stripHtml(note.content.rendered);
+				lines.push(`  "${rawContent}"`);
+				renderReplies(note.id, 1);
+				lines.push('');
 			}
-		}
-	);
-
-	server.registerTool(
-		'wp_reply_to_note',
-		{
-			description:
-				'Reply to an existing note. Replies are threaded under the parent note.',
-			inputSchema: {
-				noteId: z.number().describe('ID of the note to reply to'),
-				content: z.string().describe('Reply text'),
-			},
+			return lines.join('\n').trim();
 		},
-		async ({ noteId, content }) => {
-			try {
-				const reply = await session.replyToNote(noteId, content);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Added reply #${reply.id} to note #${noteId}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to reply to note: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_resolve_note',
-		{
-			description:
-				'Resolve (delete) a note and remove its association from the linked block.',
-			inputSchema: {
-				noteId: z.number().describe('ID of the note to resolve'),
-			},
+		tags: ['notes'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_add_note',
+		description:
+			'Add a note (block comment) to a specific block. Notes are editorial feedback visible in the WordPress editor but not shown to site visitors.',
+		inputSchema: {
+			blockIndex: z
+				.string()
+				.describe('Block index (e.g. "0", "2.1" for nested blocks)'),
+			content: z.string().describe('Note text'),
 		},
-		async ({ noteId }) => {
-			try {
-				await session.resolveNote(noteId);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Resolved note #${noteId}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to resolve note: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_update_note',
-		{
-			description: 'Update the content of an existing note.',
-			inputSchema: {
-				noteId: z.number().describe('ID of the note to update'),
-				content: z.string().describe('New note text'),
-			},
+		execute: async (
+			session,
+			{ blockIndex, content }: { blockIndex: string; content: string }
+		) => {
+			const note = await session.addNote(blockIndex, content);
+			return `Added note #${note.id} to block [${blockIndex}].`;
 		},
-		async ({ noteId, content }) => {
-			try {
-				await session.updateNote(noteId, content);
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Updated note #${noteId}.`,
-						},
-					],
-				};
-			} catch (err) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to update note: ${(err as Error).message}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-}
+		tags: ['notes'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_reply_to_note',
+		description:
+			'Reply to an existing note. Replies are threaded under the parent note.',
+		inputSchema: {
+			noteId: z.number().describe('ID of the note to reply to'),
+			content: z.string().describe('Reply text'),
+		},
+		execute: async (
+			session,
+			{ noteId, content }: { noteId: number; content: string }
+		) => {
+			const reply = await session.replyToNote(noteId, content);
+			return `Added reply #${reply.id} to note #${noteId}.`;
+		},
+		tags: ['notes'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_resolve_note',
+		description:
+			'Resolve (delete) a note and remove its association from the linked block.',
+		inputSchema: {
+			noteId: z.number().describe('ID of the note to resolve'),
+		},
+		execute: async (session, { noteId }: { noteId: number }) => {
+			await session.resolveNote(noteId);
+			return `Resolved note #${noteId}.`;
+		},
+		tags: ['notes'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_update_note',
+		description: 'Update the content of an existing note.',
+		inputSchema: {
+			noteId: z.number().describe('ID of the note to update'),
+			content: z.string().describe('New note text'),
+		},
+		execute: async (
+			session,
+			{ noteId, content }: { noteId: number; content: string }
+		) => {
+			await session.updateNote(noteId, content);
+			return `Updated note #${noteId}.`;
+		},
+		tags: ['notes'],
+		availableIn: ['editing'],
+	},
+];

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -1,175 +1,97 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
 
-export function registerPostTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_list_posts',
-		{
-			description:
-				'List WordPress posts with optional filters. By default, this shows published posts; specify a status filter if you want to see drafts or other non-published posts.',
-			inputSchema: {
-				status: z
-					.string()
-					.optional()
-					.describe(
-						'Filter by post status (e.g., publish, draft, pending)'
-					),
-				search: z
-					.string()
-					.optional()
-					.describe('Search posts by keyword'),
-				perPage: z
-					.number()
-					.optional()
-					.describe('Number of posts to return (default 10)'),
-			},
-		},
-		async ({ status, search, perPage }) => {
-			try {
-				const posts = await session.listPosts({
-					status,
-					search,
-					perPage,
-				});
-				if (posts.length === 0) {
-					return {
-						content: [
-							{ type: 'text' as const, text: 'No posts found.' },
-						],
-					};
-				}
-
-				const lines = posts.map(
-					(post, i) =>
-						`${i + 1}. [${post.id}] ${post.title.raw ?? post.title.rendered} (${post.status})`
-				);
-
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Found ${posts.length} posts:\n\n${lines.join('\n')}`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to list posts: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_open_post',
-		{
-			description: 'Open a WordPress post for collaborative editing',
-			inputSchema: {
-				postId: z.number().describe('The post ID to open'),
-			},
-		},
-		async ({ postId }) => {
-			try {
-				await session.openPost(postId);
-				const content = session.readPost();
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Opened post ${postId} for editing.\n\n${content}`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to open post: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_close_post',
-		{
-			description:
-				'Close the current post and stop syncing, without disconnecting from WordPress',
-		},
-		async () => {
-			try {
-				await session.closePost();
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: 'Post closed. You can now open another post with wp_open_post or wp_create_post.',
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to close post: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_create_post',
-		{
-			description: 'Create a new WordPress post and open it for editing',
-			inputSchema: {
-				title: z.string().optional().describe('Post title'),
-				content: z
-					.string()
-					.optional()
-					.describe('Initial post content (Gutenberg HTML)'),
-			},
-		},
-		async ({ title, content }) => {
-			try {
-				const post = await session.createPost({ title, content });
-				const rendered = session.readPost();
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Created and opened post ${post.id}.\n\n${rendered}`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to create post: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
+interface ListPostsInput {
+	status?: string;
+	search?: string;
+	perPage?: number;
 }
+
+export const postTools: ToolDefinition[] = [
+	{
+		name: 'wp_list_posts',
+		description:
+			'List WordPress posts with optional filters. By default, this shows published posts; specify a status filter if you want to see drafts or other non-published posts.',
+		inputSchema: {
+			status: z
+				.string()
+				.optional()
+				.describe(
+					'Filter by post status (e.g., publish, draft, pending)'
+				),
+			search: z.string().optional().describe('Search posts by keyword'),
+			perPage: z
+				.number()
+				.optional()
+				.describe('Number of posts to return (default 10)'),
+		},
+		availableIn: ['connected', 'editing'],
+		tags: ['posts'],
+		execute: async (
+			session,
+			{ status, search, perPage }: ListPostsInput
+		) => {
+			const posts = await session.listPosts({
+				status,
+				search,
+				perPage,
+			});
+			if (posts.length === 0) {
+				return 'No posts found.';
+			}
+
+			const lines = posts.map(
+				(post, i) =>
+					`${i + 1}. [${post.id}] ${post.title.raw ?? post.title.rendered} (${post.status})`
+			);
+
+			return `Found ${posts.length} posts:\n\n${lines.join('\n')}`;
+		},
+	},
+	{
+		name: 'wp_open_post',
+		description: 'Open a WordPress post for collaborative editing',
+		inputSchema: {
+			postId: z.number().describe('The post ID to open'),
+		},
+		availableIn: ['connected'],
+		tags: ['posts'],
+		execute: async (session, { postId }: { postId: number }) => {
+			await session.openPost(postId);
+			const content = session.readPost();
+			return `Opened post ${postId} for editing.\n\n${content}`;
+		},
+	},
+	{
+		name: 'wp_close_post',
+		description:
+			'Close the current post and stop syncing, without disconnecting from WordPress',
+		availableIn: ['editing'],
+		tags: ['posts'],
+		execute: async (session) => {
+			await session.closePost();
+			return 'Post closed. You can now open another post with wp_open_post or wp_create_post.';
+		},
+	},
+	{
+		name: 'wp_create_post',
+		description: 'Create a new WordPress post and open it for editing',
+		inputSchema: {
+			title: z.string().optional().describe('Post title'),
+			content: z
+				.string()
+				.optional()
+				.describe('Initial post content (Gutenberg HTML)'),
+		},
+		availableIn: ['connected'],
+		tags: ['posts'],
+		execute: async (
+			session,
+			{ title, content }: { title?: string; content?: string }
+		) => {
+			const post = await session.createPost({ title, content });
+			const rendered = session.readPost();
+			return `Created and opened post ${post.id}.\n\n${rendered}`;
+		},
+	},
+];

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,64 +1,26 @@
 import { z } from 'zod';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { SessionManager } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
 
-export function registerReadTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_read_post',
-		{ description: 'Read the current post content as a block listing' },
-		() => {
-			try {
-				const content = session.readPost();
-				return {
-					content: [{ type: 'text' as const, text: content }],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to read post: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-
-	server.registerTool(
-		'wp_read_block',
-		{
-			description:
-				'Read a specific block by index (supports dot notation for nested blocks, e.g., "2.1")',
-			inputSchema: {
-				index: z
-					.string()
-					.describe(
-						'Block index (e.g., "0", "2.1" for nested blocks)'
-					),
-			},
+export const readTools: ToolDefinition[] = [
+	{
+		name: 'wp_read_post',
+		description: 'Read the current post content as a block listing',
+		availableIn: ['editing'],
+		tags: ['reading'],
+		execute: (session) => session.readPost(),
+	},
+	{
+		name: 'wp_read_block',
+		description:
+			'Read a specific block by index (supports dot notation for nested blocks, e.g., "2.1")',
+		inputSchema: {
+			index: z
+				.string()
+				.describe('Block index (e.g., "0", "2.1" for nested blocks)'),
 		},
-		({ index }) => {
-			try {
-				const content = session.readBlock(index);
-				return {
-					content: [{ type: 'text' as const, text: content }],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to read block: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
-			}
-		}
-	);
-}
+		availableIn: ['editing'],
+		tags: ['reading'],
+		execute: (session, { index }: { index: string }) =>
+			session.readBlock(index),
+	},
+];

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,0 +1,98 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionManager } from '../session/session-manager.js';
+import type { SessionState } from '../session/session-manager.js';
+import type { ToolDefinition } from './definitions.js';
+
+import { connectTools } from './connect.js';
+import { postTools } from './posts.js';
+import { readTools } from './read.js';
+import { editTools } from './edit.js';
+import { statusTools } from './status.js';
+import { blockTypeTools } from './block-types.js';
+import { mediaTools } from './media.js';
+import { noteTools } from './notes.js';
+import { metadataTools } from './metadata.js';
+import { commandTools } from './commands.js';
+
+/** All tool definitions, aggregated from every tool file. */
+export const allTools: ToolDefinition[] = [
+	...connectTools,
+	...postTools,
+	...readTools,
+	...editTools,
+	...statusTools,
+	...blockTypeTools,
+	...mediaTools,
+	...noteTools,
+	...metadataTools,
+	...commandTools,
+];
+
+export function getToolByName(name: string): ToolDefinition | undefined {
+	return allTools.find((t) => t.name === name);
+}
+
+export function getToolsForState(state: SessionState): ToolDefinition[] {
+	return allTools.filter(
+		(t) => !t.availableIn || t.availableIn.includes(state)
+	);
+}
+
+export function getToolsByTag(tag: string): ToolDefinition[] {
+	return allTools.filter((t) => t.tags?.includes(tag));
+}
+
+/**
+ * Register a set of tool definitions on an MCP server instance.
+ * Wraps each tool's execute function with uniform error handling.
+ */
+export function registerToolDefinitions(
+	server: McpServer,
+	session: SessionManager,
+	tools: ToolDefinition[]
+): void {
+	for (const tool of tools) {
+		server.registerTool(
+			tool.name,
+			{
+				description: tool.description,
+				...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {}),
+			},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic dispatch, validated by Zod
+			async (input: any) => {
+				try {
+					const result = await tool.execute(session, input);
+					if (typeof result === 'string') {
+						return {
+							content: [{ type: 'text' as const, text: result }],
+						};
+					}
+					return {
+						content: [{ type: 'text' as const, text: result.text }],
+						...(result.isError ? { isError: true } : {}),
+					};
+				} catch (error) {
+					return {
+						content: [
+							{
+								type: 'text' as const,
+								text: `${tool.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+							},
+						],
+						isError: true,
+					};
+				}
+			}
+		);
+	}
+}
+
+/**
+ * Register all tools on an MCP server instance.
+ */
+export function registerAllTools(
+	server: McpServer,
+	session: SessionManager
+): void {
+	registerToolDefinitions(server, session, allTools);
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -43,6 +43,20 @@ export function getToolsByTag(tag: string): ToolDefinition[] {
 }
 
 /**
+ * Format a thrown value into a readable error message.
+ * Handles Error instances, strings, and arbitrary objects safely.
+ */
+function formatThrown(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
+
+/**
  * Register a set of tool definitions on an MCP server instance.
  * Wraps each tool's execute function with uniform error handling.
  */
@@ -76,7 +90,7 @@ export function registerToolDefinitions(
 						content: [
 							{
 								type: 'text' as const,
-								text: `${tool.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+								text: `${tool.name} failed: ${formatThrown(error)}`,
 							},
 						],
 						isError: true,

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -1,25 +1,20 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SessionManager } from '../session/session-manager.js';
 import { VERSION } from '../version.js';
 import { WordPressApiError } from '../wordpress/api-client.js';
+import type { ToolDefinition, ToolResult } from './definitions.js';
 
 function getPluginDownloadUrl(): string {
 	return `https://github.com/pento/claudaborative-editing/releases/download/v${VERSION}/claudaborative-editing-plugin.zip`;
 }
 
-export function registerStatusTools(
-	server: McpServer,
-	session: SessionManager
-): void {
-	server.registerTool(
-		'wp_status',
-		{
-			description:
-				'Show current connection state, sync status, and post info. ' +
-				'If the plugin status includes URLs (download or admin links), ' +
-				'always show them to the user as clickable links.',
-		},
-		async () => {
+export const statusTools: ToolDefinition[] = [
+	{
+		name: 'wp_status',
+		description:
+			'Show current connection state, sync status, and post info. ' +
+			'If the plugin status includes URLs (download or admin links), ' +
+			'always show them to the user as clickable links.',
+		execute: async (session) => {
 			const state = session.getState();
 			const lines: string[] = [];
 
@@ -88,100 +83,57 @@ export function registerStatusTools(
 				}
 			}
 
-			return {
-				content: [{ type: 'text' as const, text: lines.join('\n') }],
-			};
-		}
-	);
-
-	server.registerTool(
-		'wp_collaborators',
-		{ description: 'List active collaborators on the current post' },
-		() => {
-			try {
-				const state = session.getState();
-				if (state !== 'editing') {
-					return {
-						content: [
-							{
-								type: 'text' as const,
-								text: 'No post is currently open for editing.',
-							},
-						],
-						isError: true,
-					};
-				}
-
-				const collaborators = session.getCollaborators();
-				const user = session.getUser();
-
-				const lines: string[] = ['Active collaborators:'];
-
-				// Add ourselves first
-				if (user) {
-					lines.push(
-						`- ${user.name} (AI, Claudaborative Editing MCP)`
-					);
-				}
-
-				// Add remote collaborators
-				for (const collab of collaborators) {
-					lines.push(
-						`- ${collab.name} (Human, ${collab.browserType})`
-					);
-				}
-
-				if (collaborators.length === 0 && !user) {
-					lines.push('- No collaborators detected');
-				}
-
+			return lines.join('\n');
+		},
+		tags: ['status'],
+	},
+	{
+		name: 'wp_collaborators',
+		description: 'List active collaborators on the current post',
+		execute: (session): string | ToolResult => {
+			const state = session.getState();
+			if (state !== 'editing') {
 				return {
-					content: [
-						{ type: 'text' as const, text: lines.join('\n') },
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to get collaborators: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
+					text: 'No post is currently open for editing.',
 					isError: true,
 				};
 			}
-		}
-	);
 
-	server.registerTool(
-		'wp_save',
-		{ description: 'Save the current post' },
-		async () => {
-			try {
-				await session.save();
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Post "${session.getTitle()}" saved.`,
-						},
-					],
-				};
-			} catch (error) {
-				return {
-					content: [
-						{
-							type: 'text' as const,
-							text: `Failed to save: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+			const collaborators = session.getCollaborators();
+			const user = session.getUser();
+
+			const lines: string[] = ['Active collaborators:'];
+
+			// Add ourselves first
+			if (user) {
+				lines.push(`- ${user.name} (AI, Claudaborative Editing MCP)`);
 			}
-		}
-	);
-}
+
+			// Add remote collaborators
+			for (const collab of collaborators) {
+				lines.push(`- ${collab.name} (Human, ${collab.browserType})`);
+			}
+
+			if (collaborators.length === 0 && !user) {
+				lines.push('- No collaborators detected');
+			}
+
+			return lines.join('\n');
+		},
+		tags: ['status'],
+		availableIn: ['editing'],
+	},
+	{
+		name: 'wp_save',
+		description: 'Save the current post',
+		execute: async (session) => {
+			await session.save();
+			return `Post "${session.getTitle()}" saved.`;
+		},
+		tags: ['status'],
+		availableIn: ['editing'],
+	},
+];
 
 /**
  * Try to get the editor plugin running. Attempts, in order:

--- a/tests/unit/document-manager.test.ts
+++ b/tests/unit/document-manager.test.ts
@@ -563,6 +563,25 @@ describe('DocumentManager', () => {
 				'<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'
 			);
 		});
+
+		it('Updates, and gets Y.text content', () => {
+			const { manager, doc } = createManager();
+			manager
+				.getDocumentMap(doc)
+				.set('content', new Y.Text('Initial content'));
+			const ytext = manager.getContent(doc);
+			expect(ytext).toBe('Initial content');
+
+			manager.setContent(doc, 'Updated content');
+			const updatedYText = manager.getContent(doc);
+			expect(updatedYText).toBe('Updated content');
+			expect(manager.getDocumentMap(doc).get('content')).toBeInstanceOf(
+				Y.Text
+			);
+			expect(
+				(manager.getDocumentMap(doc).get('content') as Y.Text).toJSON()
+			).toBe('Updated content');
+		});
 	});
 
 	describe('getBlockAttributeYText', () => {

--- a/tests/unit/document-manager.test.ts
+++ b/tests/unit/document-manager.test.ts
@@ -564,7 +564,7 @@ describe('DocumentManager', () => {
 			);
 		});
 
-		it('Updates, and gets Y.text content', () => {
+		it('updates, and gets Y.Text content', () => {
 			const { manager, doc } = createManager();
 			manager
 				.getDocumentMap(doc)
@@ -797,7 +797,7 @@ describe('DocumentManager', () => {
 			expect(manager.getProperty(doc, 'excerpt')).toBe('A summary');
 		});
 
-		it('sets, updates, and gets Y.text properties', () => {
+		it('sets, updates, and gets Y.Text properties', () => {
 			const { manager, doc } = createManager();
 
 			const ytext = new Y.Text('Rich text content');

--- a/tests/unit/document-manager.test.ts
+++ b/tests/unit/document-manager.test.ts
@@ -778,6 +778,18 @@ describe('DocumentManager', () => {
 			expect(manager.getProperty(doc, 'excerpt')).toBe('A summary');
 		});
 
+		it('sets, updates, and gets Y.text properties', () => {
+			const { manager, doc } = createManager();
+
+			const ytext = new Y.Text('Rich text content');
+			manager.setProperty(doc, 'content', ytext);
+
+			manager.setProperty(doc, 'content', 'Updated content');
+
+			const result = manager.getProperty(doc, 'content');
+			expect(result).toBe('Updated content');
+		});
+
 		it('returns undefined for unset properties', () => {
 			const { manager, doc } = createManager();
 			expect(manager.getProperty(doc, 'nonexistent')).toBeUndefined();

--- a/tests/unit/prompts/authoring.test.ts
+++ b/tests/unit/prompts/authoring.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createMockServer, createMockSession, fakePost } from './helpers.js';
-import { registerAuthoringPrompts } from '../../../src/prompts/authoring.js';
+import { authoringPrompts } from '../../../src/prompts/authoring.js';
+import { registerPromptDefinitions } from '../../../src/prompts/registry.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { assertDefined } from '../../test-utils.js';
 
@@ -9,7 +10,11 @@ describe('translate', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerAuthoringPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				authoringPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('translate');
 			assertDefined(prompt);
@@ -23,7 +28,11 @@ describe('translate', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerAuthoringPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				authoringPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('translate');
 			assertDefined(prompt);
@@ -44,7 +53,11 @@ describe('translate', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerAuthoringPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				authoringPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('translate');
 			assertDefined(prompt);
@@ -64,7 +77,11 @@ describe('translate', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerAuthoringPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				authoringPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('translate');
 			assertDefined(prompt);
@@ -80,7 +97,11 @@ describe('translate', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerAuthoringPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				authoringPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('translate');
 			assertDefined(prompt);

--- a/tests/unit/prompts/compose.test.ts
+++ b/tests/unit/prompts/compose.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createMockServer, createMockSession, fakePost } from './helpers.js';
-import { registerComposePrompts } from '../../../src/prompts/compose.js';
+import { composePrompts } from '../../../src/prompts/compose.js';
+import { registerPromptDefinitions } from '../../../src/prompts/registry.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { assertDefined } from '../../test-utils.js';
 
 describe('compose', () => {
@@ -8,7 +10,11 @@ describe('compose', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -22,7 +28,11 @@ describe('compose', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -42,7 +52,11 @@ describe('compose', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -61,7 +75,11 @@ describe('compose', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -79,7 +97,11 @@ describe('compose', () => {
 				post: fakePost,
 			});
 			vi.mocked(session.getNotesSupported).mockReturnValue(false);
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -98,7 +120,11 @@ describe('compose', () => {
 				post: fakePost,
 				postContent: '',
 			});
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -114,7 +140,11 @@ describe('compose', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerComposePrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				composePrompts
+			);
 
 			const prompt = server.registeredPrompts.get('compose');
 			assertDefined(prompt);
@@ -130,7 +160,11 @@ describe('compose', () => {
 	it('has the correct description', () => {
 		const server = createMockServer();
 		const session = createMockSession({ state: 'disconnected' });
-		registerComposePrompts(server, session);
+		registerPromptDefinitions(
+			server as unknown as McpServer,
+			session,
+			composePrompts
+		);
 
 		const prompt = server.registeredPrompts.get('compose');
 		assertDefined(prompt);

--- a/tests/unit/prompts/editing.test.ts
+++ b/tests/unit/prompts/editing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createMockServer, createMockSession, fakePost } from './helpers.js';
-import { registerEditingPrompts } from '../../../src/prompts/editing.js';
+import { editingPrompts } from '../../../src/prompts/editing.js';
+import { registerPromptDefinitions } from '../../../src/prompts/registry.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SessionManager } from '../../../src/session/session-manager.js';
 import type { RegisteredPrompt } from './helpers.js';
@@ -11,7 +12,11 @@ describe('edit', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('edit');
 			assertDefined(prompt);
@@ -25,7 +30,11 @@ describe('edit', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('edit');
 			assertDefined(prompt);
@@ -49,7 +58,11 @@ describe('edit', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 			const editPrompt = server.registeredPrompts.get('edit');
 			assertDefined(editPrompt);
 			prompt = editPrompt;
@@ -82,7 +95,11 @@ describe('proofread', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('proofread');
 			assertDefined(prompt);
@@ -96,7 +113,11 @@ describe('proofread', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('proofread');
 			assertDefined(prompt);
@@ -120,7 +141,11 @@ describe('proofread', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerEditingPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				editingPrompts
+			);
 			const proofreadPrompt = server.registeredPrompts.get('proofread');
 			assertDefined(proofreadPrompt);
 			prompt = proofreadPrompt;

--- a/tests/unit/prompts/pre-publish.test.ts
+++ b/tests/unit/prompts/pre-publish.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createMockServer, createMockSession, fakePost } from './helpers.js';
-import { registerPrePublishPrompts } from '../../../src/prompts/pre-publish.js';
+import { prePublishPrompts } from '../../../src/prompts/pre-publish.js';
+import { registerPromptDefinitions } from '../../../src/prompts/registry.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SessionManager } from '../../../src/session/session-manager.js';
 import type { RegisteredPrompt } from './helpers.js';
@@ -11,7 +12,11 @@ describe('pre-publish-check', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerPrePublishPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				prePublishPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('pre-publish-check');
 			assertDefined(prompt);
@@ -25,7 +30,11 @@ describe('pre-publish-check', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerPrePublishPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				prePublishPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('pre-publish-check');
 			assertDefined(prompt);
@@ -49,7 +58,11 @@ describe('pre-publish-check', () => {
 				post: fakePost,
 				postContent,
 			});
-			registerPrePublishPrompts(server as unknown as McpServer, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				prePublishPrompts
+			);
 			const prePublishPrompt =
 				server.registeredPrompts.get('pre-publish-check');
 			assertDefined(prePublishPrompt);

--- a/tests/unit/prompts/registry.test.ts
+++ b/tests/unit/prompts/registry.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+	allPrompts,
+	getPromptByName,
+	registerAllPrompts,
+	registerPromptDefinitions,
+} from '../../../src/prompts/registry.js';
+import { createMockServer, createMockSession } from './helpers.js';
+import { assertDefined } from '../../test-utils.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PromptDefinition } from '../../../src/prompts/definitions.js';
+
+describe('prompts/registry', () => {
+	describe('allPrompts', () => {
+		it('aggregates all 8 prompt definitions', () => {
+			expect(allPrompts.length).toBe(8);
+		});
+
+		it('contains known prompts from different files', () => {
+			const names = allPrompts.map((p) => p.name);
+			expect(names).toContain('edit');
+			expect(names).toContain('proofread');
+			expect(names).toContain('review');
+			expect(names).toContain('respond-to-notes');
+			expect(names).toContain('respond-to-note');
+			expect(names).toContain('translate');
+			expect(names).toContain('compose');
+			expect(names).toContain('pre-publish-check');
+		});
+	});
+
+	describe('getPromptByName', () => {
+		it('returns a prompt definition by name', () => {
+			const prompt = getPromptByName('review');
+			assertDefined(prompt);
+			expect(prompt.name).toBe('review');
+			expect(prompt.description).toContain('editorial feedback');
+		});
+
+		it('returns undefined for unknown names', () => {
+			expect(getPromptByName('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('registerPromptDefinitions', () => {
+		it('wraps buildMessages and converts content to MCP format', async () => {
+			const server = createMockServer();
+			const session = createMockSession({ state: 'disconnected' });
+
+			const testPrompts: PromptDefinition[] = [
+				{
+					name: 'test-prompt',
+					description: 'A test prompt',
+					buildMessages: () => ({
+						description: 'Test description',
+						messages: [
+							{ role: 'user', content: 'Hello from test' },
+						],
+					}),
+				},
+			];
+
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				testPrompts
+			);
+
+			const registered = server.registeredPrompts.get('test-prompt');
+			assertDefined(registered);
+
+			const result = await registered.handler({});
+			expect(result.description).toBe('Test description');
+			expect(result.messages[0]).toEqual({
+				role: 'user',
+				content: { type: 'text', text: 'Hello from test' },
+			});
+		});
+	});
+
+	describe('registerAllPrompts', () => {
+		it('registers all prompts on the MCP server', () => {
+			const server = createMockServer();
+			const session = createMockSession();
+			registerAllPrompts(server as unknown as McpServer, session);
+			expect(server.registeredPrompts.size).toBe(8);
+		});
+	});
+});

--- a/tests/unit/prompts/review.test.ts
+++ b/tests/unit/prompts/review.test.ts
@@ -6,7 +6,9 @@ import {
 	fakePost,
 	fakeNote,
 } from './helpers.js';
-import { registerReviewPrompts } from '../../../src/prompts/review.js';
+import { reviewPrompts } from '../../../src/prompts/review.js';
+import { registerPromptDefinitions } from '../../../src/prompts/registry.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { assertDefined } from '../../test-utils.js';
 
 describe('review', () => {
@@ -14,7 +16,11 @@ describe('review', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -29,7 +35,11 @@ describe('review', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -47,7 +57,11 @@ describe('review', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -67,7 +81,11 @@ describe('review', () => {
 				post: fakePost,
 			});
 			vi.mocked(session.getNotesSupported).mockReturnValue(false);
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -85,7 +103,11 @@ describe('review', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -101,7 +123,11 @@ describe('review', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('review');
 			assertDefined(prompt);
@@ -118,7 +144,11 @@ describe('respond-to-notes', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -133,7 +163,11 @@ describe('respond-to-notes', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -152,7 +186,11 @@ describe('respond-to-notes', () => {
 				post: fakePost,
 			});
 			vi.mocked(session.getNotesSupported).mockReturnValue(false);
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -168,7 +206,11 @@ describe('respond-to-notes', () => {
 				state: 'editing',
 				post: fakePost,
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -188,7 +230,11 @@ describe('respond-to-notes', () => {
 				notes: [fakeNote],
 				noteBlockMap: { 1: '0' },
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -222,7 +268,11 @@ describe('respond-to-notes', () => {
 				notes: [fakeNote, replyNote],
 				noteBlockMap: { 1: '0' },
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-notes');
 			assertDefined(prompt);
@@ -241,7 +291,11 @@ describe('respond-to-note', () => {
 		it('instructs to connect first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'disconnected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);
@@ -256,7 +310,11 @@ describe('respond-to-note', () => {
 		it('instructs to open a post first', async () => {
 			const server = createMockServer();
 			const session = createMockSession({ state: 'connected' });
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);
@@ -275,7 +333,11 @@ describe('respond-to-note', () => {
 				post: fakePost,
 			});
 			vi.mocked(session.getNotesSupported).mockReturnValue(false);
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);
@@ -295,7 +357,11 @@ describe('respond-to-note', () => {
 				notes: [fakeNote],
 				noteBlockMap: { 1: '0' },
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);
@@ -333,7 +399,11 @@ describe('respond-to-note', () => {
 				notes: [fakeNote, replyNote, otherNote],
 				noteBlockMap: { 1: '0', 10: '1' },
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);
@@ -366,7 +436,11 @@ describe('respond-to-note', () => {
 				notes: [fakeNote],
 				noteBlockMap: { 1: '0' },
 			});
-			registerReviewPrompts(server, session);
+			registerPromptDefinitions(
+				server as unknown as McpServer,
+				session,
+				reviewPrompts
+			);
 
 			const prompt = server.registeredPrompts.get('respond-to-note');
 			assertDefined(prompt);

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -58,35 +58,12 @@ vi.mock('../../src/session/session-manager.js', () => {
 	};
 });
 
-// --- Mock tool registration functions (no-ops) ---
-vi.mock('../../src/tools/connect.js', () => ({
-	registerConnectTools: vi.fn(),
+// --- Mock tool and prompt registration (no-ops) ---
+vi.mock('../../src/tools/registry.js', () => ({
+	registerAllTools: vi.fn(),
 }));
-vi.mock('../../src/tools/posts.js', () => ({ registerPostTools: vi.fn() }));
-vi.mock('../../src/tools/read.js', () => ({ registerReadTools: vi.fn() }));
-vi.mock('../../src/tools/edit.js', () => ({ registerEditTools: vi.fn() }));
-vi.mock('../../src/tools/status.js', () => ({ registerStatusTools: vi.fn() }));
-vi.mock('../../src/tools/block-types.js', () => ({
-	registerBlockTypeTools: vi.fn(),
-}));
-vi.mock('../../src/tools/media.js', () => ({ registerMediaTools: vi.fn() }));
-vi.mock('../../src/tools/notes.js', () => ({ registerNoteTools: vi.fn() }));
-vi.mock('../../src/tools/metadata.js', () => ({
-	registerMetadataTools: vi.fn(),
-}));
-vi.mock('../../src/tools/commands.js', () => ({
-	registerCommandTools: vi.fn(),
-}));
-
-// --- Mock prompt registration functions (no-ops) ---
-vi.mock('../../src/prompts/editing.js', () => ({
-	registerEditingPrompts: vi.fn(),
-}));
-vi.mock('../../src/prompts/review.js', () => ({
-	registerReviewPrompts: vi.fn(),
-}));
-vi.mock('../../src/prompts/authoring.js', () => ({
-	registerAuthoringPrompts: vi.fn(),
+vi.mock('../../src/prompts/registry.js', () => ({
+	registerAllPrompts: vi.fn(),
 }));
 
 describe('startServer()', () => {

--- a/tests/unit/tools/block-types.test.ts
+++ b/tests/unit/tools/block-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerBlockTypeTools } from '../../../src/tools/block-types.js';
+import { blockTypeTools } from '../../../src/tools/block-types.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import { createMockServer, createMockSession } from './helpers.js';
 import { assertDefined } from '../../test-utils.js';
 import { BlockTypeRegistry } from '../../../src/yjs/block-type-registry.js';
@@ -73,7 +74,11 @@ describe('block-types tool', () => {
 	beforeEach(() => {
 		server = createMockServer();
 		session = createSessionWithRegistry(sampleBlockTypes);
-		registerBlockTypeTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			blockTypeTools
+		);
 	});
 
 	it('registers wp_block_types tool', () => {
@@ -158,7 +163,11 @@ describe('block-types tool', () => {
 		it('shows reconnect hint when connected with fallback registry', async () => {
 			server = createMockServer();
 			session = createSessionWithFallbackRegistry();
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);
@@ -178,7 +187,11 @@ describe('block-types tool', () => {
 			Object.assign(session, {
 				getRegistry: vi.fn().mockReturnValue(registry),
 			});
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);
@@ -201,7 +214,11 @@ describe('block-types tool', () => {
 					throw new Error('registry unavailable');
 				}),
 			});
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);
@@ -229,7 +246,11 @@ describe('block-types tool', () => {
 					allowed_blocks: ['core/column'],
 				},
 			]);
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);
@@ -255,7 +276,11 @@ describe('block-types tool', () => {
 					ancestor: ['core/comment-template'],
 				},
 			]);
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);
@@ -287,7 +312,11 @@ describe('block-types tool', () => {
 					supports: { allowedBlocks: true },
 				},
 			]);
-			registerBlockTypeTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				blockTypeTools
+			);
 
 			const tool = server.registeredTools.get('wp_block_types');
 			assertDefined(tool);

--- a/tests/unit/tools/commands.test.ts
+++ b/tests/unit/tools/commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { ZodType } from 'zod';
-import { registerCommandTools } from '../../../src/tools/commands.js';
+import { commandTools } from '../../../src/tools/commands.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import { createMockServer, createMockSession } from './helpers.js';
 import { assertDefined } from '../../test-utils.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -14,7 +15,11 @@ describe('command tools', () => {
 
 	it('registers wp_update_command_status', () => {
 		const session = createMockSession();
-		registerCommandTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			commandTools
+		);
 
 		expect(server.registeredTools.has('wp_update_command_status')).toBe(
 			true
@@ -24,7 +29,11 @@ describe('command tools', () => {
 	describe('wp_update_command_status', () => {
 		it('updates command status and returns confirmation', async () => {
 			const session = createMockSession();
-			registerCommandTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				commandTools
+			);
 
 			const tool = server.registeredTools.get('wp_update_command_status');
 			assertDefined(tool);
@@ -48,7 +57,11 @@ describe('command tools', () => {
 
 		it('passes resultData parameter when provided', async () => {
 			const session = createMockSession();
-			registerCommandTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				commandTools
+			);
 
 			const tool = server.registeredTools.get('wp_update_command_status');
 			assertDefined(tool);
@@ -85,7 +98,11 @@ describe('command tools', () => {
 					typeof import('vitest').vi.fn
 				>
 			).mockRejectedValue(new Error('Network timeout'));
-			registerCommandTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				commandTools
+			);
 
 			const tool = server.registeredTools.get('wp_update_command_status');
 			assertDefined(tool);
@@ -97,7 +114,7 @@ describe('command tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to update command status: Network timeout'
+				'wp_update_command_status failed: Network timeout'
 			);
 		});
 
@@ -108,7 +125,11 @@ describe('command tools', () => {
 					typeof import('vitest').vi.fn
 				>
 			).mockRejectedValue('What a weird error');
-			registerCommandTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				commandTools
+			);
 
 			const tool = server.registeredTools.get('wp_update_command_status');
 			assertDefined(tool);
@@ -120,14 +141,18 @@ describe('command tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to update command status: What a weird error'
+				'wp_update_command_status failed: What a weird error'
 			);
 		});
 
 		describe('resultData schema validation', () => {
 			function getResultDataSchema(): ZodType {
 				const session = createMockSession();
-				registerCommandTools(server as unknown as McpServer, session);
+				registerToolDefinitions(
+					server as unknown as McpServer,
+					session,
+					commandTools
+				);
 				const tool = server.registeredTools.get(
 					'wp_update_command_status'
 				);
@@ -175,7 +200,11 @@ describe('command tools', () => {
 			).mockRejectedValue(
 				new Error('WordPress editor plugin is not connected')
 			);
-			registerCommandTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				commandTools
+			);
 
 			const tool = server.registeredTools.get('wp_update_command_status');
 			assertDefined(tool);

--- a/tests/unit/tools/connect.test.ts
+++ b/tests/unit/tools/connect.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { registerConnectTools } from '../../../src/tools/connect.js';
+import { connectTools } from '../../../src/tools/connect.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import { createMockServer, createMockSession, fakeUser } from './helpers.js';
 import { assertDefined } from '../../test-utils.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -12,7 +13,11 @@ describe('connect tools', () => {
 	beforeEach(() => {
 		server = createMockServer();
 		session = createMockSession({ user: fakeUser });
-		registerConnectTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			connectTools
+		);
 	});
 
 	it('registers wp_connect and wp_disconnect', () => {
@@ -51,7 +56,7 @@ describe('connect tools', () => {
 				appPassword: 'bad',
 			});
 
-			expect(result.content[0].text).toContain('Connection failed');
+			expect(result.content[0].text).toContain('wp_connect failed');
 			expect(result.content[0].text).toContain('Invalid credentials');
 			expect(result.isError).toBe(true);
 		});
@@ -62,9 +67,10 @@ describe('connect tools', () => {
 				user: fakeUser,
 			});
 			const connectedServer = createMockServer();
-			registerConnectTools(
+			registerToolDefinitions(
 				connectedServer as unknown as McpServer,
-				connectedSession
+				connectedSession,
+				connectTools
 			);
 
 			const tool = connectedServer.registeredTools.get('wp_connect');
@@ -89,9 +95,10 @@ describe('connect tools', () => {
 				user: fakeUser,
 			});
 			const editingServer = createMockServer();
-			registerConnectTools(
+			registerToolDefinitions(
 				editingServer as unknown as McpServer,
-				editingSession
+				editingSession,
+				connectTools
 			);
 
 			const tool = editingServer.registeredTools.get('wp_connect');

--- a/tests/unit/tools/edit.test.ts
+++ b/tests/unit/tools/edit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { registerEditTools } from '../../../src/tools/edit.js';
+import { editTools } from '../../../src/tools/edit.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -22,7 +23,11 @@ describe('edit tools', () => {
 			post: fakePost,
 			blockContent: '[0] core/paragraph\n  "Updated content"',
 		});
-		registerEditTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			editTools
+		);
 	});
 
 	it('registers all edit tools', () => {
@@ -81,7 +86,7 @@ describe('edit tools', () => {
 			const result = await tool.handler({ index: '0', content: 'test' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to update block');
+			expect(result.content[0].text).toContain('wp_update_block failed');
 		});
 	});
 
@@ -155,9 +160,10 @@ describe('edit tools', () => {
 				},
 			});
 			const partialServer = createMockServer();
-			registerEditTools(
+			registerToolDefinitions(
 				partialServer as unknown as McpServer,
-				partialSession
+				partialSession,
+				editTools
 			);
 
 			const tool =
@@ -197,7 +203,11 @@ describe('edit tools', () => {
 				},
 			});
 			const failServer = createMockServer();
-			registerEditTools(failServer as unknown as McpServer, failSession);
+			registerToolDefinitions(
+				failServer as unknown as McpServer,
+				failSession,
+				editTools
+			);
 
 			const tool = failServer.registeredTools.get('wp_edit_block_text');
 			assertDefined(tool);
@@ -228,7 +238,7 @@ describe('edit tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to edit block text'
+				'wp_edit_block_text failed'
 			);
 			expect(result.content[0].text).toContain('Block 999 not found');
 		});
@@ -262,9 +272,10 @@ describe('edit tools', () => {
 				},
 			});
 			const multiServer = createMockServer();
-			registerEditTools(
+			registerToolDefinitions(
 				multiServer as unknown as McpServer,
-				multiSession
+				multiSession,
+				editTools
 			);
 
 			const tool = multiServer.registeredTools.get('wp_edit_block_text');
@@ -356,7 +367,7 @@ describe('edit tools', () => {
 			const result = await tool.handler({ startIndex: 99 });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to remove blocks');
+			expect(result.content[0].text).toContain('wp_remove_blocks failed');
 		});
 	});
 
@@ -384,7 +395,7 @@ describe('edit tools', () => {
 			const result = await tool.handler({ fromIndex: 99, toIndex: 0 });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to move block');
+			expect(result.content[0].text).toContain('wp_move_block failed');
 		});
 	});
 
@@ -437,7 +448,7 @@ describe('edit tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to replace blocks'
+				'wp_replace_blocks failed'
 			);
 		});
 	});
@@ -511,7 +522,7 @@ describe('edit tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to insert inner block'
+				'wp_insert_inner_block failed'
 			);
 		});
 	});
@@ -564,7 +575,7 @@ describe('edit tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to remove inner blocks'
+				'wp_remove_inner_blocks failed'
 			);
 		});
 	});
@@ -629,7 +640,7 @@ describe('edit tools', () => {
 			const result = await tool.handler({ title: 'Test' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set title');
+			expect(result.content[0].text).toContain('wp_set_title failed');
 		});
 	});
 });

--- a/tests/unit/tools/edit.test.ts
+++ b/tests/unit/tools/edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { editTools } from '../../../src/tools/edit.js';
+import { editTools, blockInputSchema } from '../../../src/tools/edit.js';
 import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
@@ -479,6 +479,64 @@ describe('edit tools', () => {
 				'Inserted core/list block at position 0'
 			);
 		});
+
+		it('passes deeply nested innerBlocks (recursive schema)', async () => {
+			const tool = server.registeredTools.get('wp_insert_block');
+			assertDefined(tool);
+			const result = await tool.handler({
+				position: 0,
+				name: 'core/columns',
+				innerBlocks: [
+					{
+						name: 'core/column',
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								content: 'Nested content',
+							},
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										content: 'Deeply nested item',
+									},
+								],
+							},
+						],
+					},
+				],
+			});
+
+			expect(session.insertBlock).toHaveBeenCalledWith(0, {
+				name: 'core/columns',
+				content: undefined,
+				attributes: undefined,
+				innerBlocks: [
+					{
+						name: 'core/column',
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								content: 'Nested content',
+							},
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										content: 'Deeply nested item',
+									},
+								],
+							},
+						],
+					},
+				],
+			});
+			expect(result.content[0].text).toContain(
+				'Inserted core/columns block at position 0'
+			);
+		});
 	});
 
 	describe('wp_insert_inner_block', () => {
@@ -641,6 +699,54 @@ describe('edit tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain('wp_set_title failed');
+		});
+	});
+
+	describe('blockInputSchema', () => {
+		it('validates deeply nested innerBlocks recursively', () => {
+			const input = {
+				name: 'core/columns',
+				innerBlocks: [
+					{
+						name: 'core/column',
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										content: 'Level 3',
+									},
+								],
+							},
+						],
+					},
+				],
+			};
+
+			const result = blockInputSchema.parse(input);
+			expect(result.name).toBe('core/columns');
+
+			const level1 = result.innerBlocks;
+			assertDefined(level1);
+			expect(level1[0].name).toBe('core/column');
+
+			const level2 = level1[0].innerBlocks;
+			assertDefined(level2);
+			expect(level2[0].name).toBe('core/list');
+
+			const level3 = level2[0].innerBlocks;
+			assertDefined(level3);
+			expect(level3[0].content).toBe('Level 3');
+		});
+
+		it('rejects invalid nested blocks', () => {
+			const input = {
+				name: 'core/columns',
+				innerBlocks: [{ notAName: 'invalid' }],
+			};
+
+			expect(() => blockInputSchema.parse(input)).toThrow();
 		});
 	});
 });

--- a/tests/unit/tools/media.test.ts
+++ b/tests/unit/tools/media.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerMediaTools } from '../../../src/tools/media.js';
+import { mediaTools } from '../../../src/tools/media.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import type { SessionManager } from '../../../src/session/session-manager.js';
 import {
 	createMockServer,
@@ -22,7 +23,11 @@ describe('media tools', () => {
 			user: fakeUser,
 			post: fakePost,
 		});
-		registerMediaTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			mediaTools
+		);
 	});
 
 	it('registers wp_upload_media tool', () => {
@@ -177,7 +182,7 @@ describe('media tools', () => {
 			});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to upload media');
+			expect(result.content[0].text).toContain('wp_upload_media failed');
 			expect(result.content[0].text).toContain('File not found');
 		});
 

--- a/tests/unit/tools/metadata.test.ts
+++ b/tests/unit/tools/metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { registerMetadataTools } from '../../../src/tools/metadata.js';
+import { metadataTools } from '../../../src/tools/metadata.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -37,7 +38,11 @@ describe('metadata tools', () => {
 			},
 		]);
 
-		registerMetadataTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			metadataTools
+		);
 	});
 
 	it('registers all 11 metadata tools', () => {
@@ -92,7 +97,7 @@ describe('metadata tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to list categories'
+				'wp_list_categories failed'
 			);
 		});
 	});
@@ -133,7 +138,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to list tags');
+			expect(result.content[0].text).toContain('wp_list_tags failed');
 		});
 	});
 
@@ -169,7 +174,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ status: 'publish' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set status');
+			expect(result.content[0].text).toContain('wp_set_status failed');
 			expect(result.content[0].text).toContain(
 				'Insufficient permissions'
 			);
@@ -241,7 +246,7 @@ describe('metadata tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to set categories'
+				'wp_set_categories failed'
 			);
 			expect(result.content[0].text).toContain('Not editing');
 		});
@@ -291,7 +296,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ tags: ['fail'] });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set tags');
+			expect(result.content[0].text).toContain('wp_set_tags failed');
 			expect(result.content[0].text).toContain('API error');
 		});
 	});
@@ -329,7 +334,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ excerpt: 'test' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set excerpt');
+			expect(result.content[0].text).toContain('wp_set_excerpt failed');
 			expect(result.content[0].text).toContain('Not editing');
 		});
 	});
@@ -366,7 +371,7 @@ describe('metadata tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to set featured image'
+				'wp_set_featured_image failed'
 			);
 			expect(result.content[0].text).toContain('Invalid attachment ID');
 		});
@@ -410,7 +415,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ date: 'not-a-date' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set date');
+			expect(result.content[0].text).toContain('wp_set_date failed');
 			expect(result.content[0].text).toContain('Invalid date format');
 		});
 	});
@@ -456,7 +461,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ slug: '' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set slug');
+			expect(result.content[0].text).toContain('wp_set_slug failed');
 			expect(result.content[0].text).toContain('Invalid slug');
 		});
 	});
@@ -490,7 +495,7 @@ describe('metadata tools', () => {
 			const result = await tool.handler({ sticky: true });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to set sticky');
+			expect(result.content[0].text).toContain('wp_set_sticky failed');
 			expect(result.content[0].text).toContain('Not editing');
 		});
 	});
@@ -525,7 +530,7 @@ describe('metadata tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to set comment status'
+				'wp_set_comment_status failed'
 			);
 			expect(result.content[0].text).toContain('Permission denied');
 		});

--- a/tests/unit/tools/notes.test.ts
+++ b/tests/unit/tools/notes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { registerNoteTools } from '../../../src/tools/notes.js';
+import { noteTools } from '../../../src/tools/notes.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -21,7 +22,11 @@ describe('note tools', () => {
 			user: fakeUser,
 			post: fakePost,
 		});
-		registerNoteTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			noteTools
+		);
 	});
 
 	it('registers all note tools', () => {
@@ -170,7 +175,7 @@ describe('note tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to list notes');
+			expect(result.content[0].text).toContain('wp_list_notes failed');
 		});
 	});
 
@@ -200,7 +205,7 @@ describe('note tools', () => {
 			});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to add note');
+			expect(result.content[0].text).toContain('wp_add_note failed');
 		});
 	});
 
@@ -227,7 +232,7 @@ describe('note tools', () => {
 			const result = await tool.handler({ noteId: 999, content: 'test' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to reply to note');
+			expect(result.content[0].text).toContain('wp_reply_to_note failed');
 		});
 	});
 
@@ -251,7 +256,7 @@ describe('note tools', () => {
 			const result = await tool.handler({ noteId: 999 });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to resolve note');
+			expect(result.content[0].text).toContain('wp_resolve_note failed');
 		});
 	});
 
@@ -281,7 +286,7 @@ describe('note tools', () => {
 			const result = await tool.handler({ noteId: 999, content: 'test' });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to update note');
+			expect(result.content[0].text).toContain('wp_update_note failed');
 		});
 	});
 });

--- a/tests/unit/tools/posts.test.ts
+++ b/tests/unit/tools/posts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { registerPostTools } from '../../../src/tools/posts.js';
+import { postTools } from '../../../src/tools/posts.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -21,7 +22,11 @@ describe('post tools', () => {
 			user: fakeUser,
 			post: fakePost,
 		});
-		registerPostTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			postTools
+		);
 	});
 
 	it('registers wp_list_posts, wp_open_post, wp_close_post, and wp_create_post', () => {
@@ -77,7 +82,7 @@ describe('post tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to list posts');
+			expect(result.content[0].text).toContain('wp_list_posts failed');
 		});
 	});
 
@@ -104,7 +109,7 @@ describe('post tools', () => {
 			const result = await tool.handler({ postId: 999 });
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to open post');
+			expect(result.content[0].text).toContain('wp_open_post failed');
 		});
 	});
 
@@ -116,7 +121,11 @@ describe('post tools', () => {
 				user: fakeUser,
 				post: fakePost,
 			});
-			registerPostTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				postTools
+			);
 		});
 
 		it('calls session.closePost() and returns success message', async () => {
@@ -143,7 +152,7 @@ describe('post tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to close post');
+			expect(result.content[0].text).toContain('wp_close_post failed');
 		});
 	});
 
@@ -172,7 +181,7 @@ describe('post tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to create post');
+			expect(result.content[0].text).toContain('wp_create_post failed');
 		});
 	});
 });

--- a/tests/unit/tools/read.test.ts
+++ b/tests/unit/tools/read.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { registerReadTools } from '../../../src/tools/read.js';
+import { readTools } from '../../../src/tools/read.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -24,7 +25,11 @@ describe('read tools', () => {
 				'Title: "My Great Post"\n\n[0] core/paragraph\n  "Hello world"',
 			blockContent: '[0] core/paragraph\n  "Hello world"',
 		});
-		registerReadTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			readTools
+		);
 	});
 
 	it('registers wp_read_post and wp_read_block', () => {
@@ -56,7 +61,7 @@ describe('read tools', () => {
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to read post');
+			expect(result.content[0].text).toContain('wp_read_post failed');
 		});
 	});
 

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -14,7 +14,7 @@ import type { ToolDefinition } from '../../../src/tools/definitions.js';
 
 describe('tools/registry', () => {
 	describe('allTools', () => {
-		it('aggregates all 33 tool definitions', () => {
+		it('aggregates all 39 tool definitions', () => {
 			expect(allTools.length).toBe(39);
 		});
 

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -241,6 +241,39 @@ describe('tools/registry', () => {
 			);
 			expect(result.isError).toBe(true);
 		});
+
+		it('falls back to String() for circular objects', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const circular: Record<string, unknown> = { name: 'loop' };
+			circular.self = circular;
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => {
+						// eslint-disable-next-line @typescript-eslint/only-throw-error
+						throw circular;
+					},
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe(
+				'test_tool failed: [object Object]'
+			);
+			expect(result.isError).toBe(true);
+		});
 	});
 
 	describe('registerAllTools', () => {

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import {
+	allTools,
+	getToolByName,
+	getToolsForState,
+	getToolsByTag,
+	registerAllTools,
+	registerToolDefinitions,
+} from '../../../src/tools/registry.js';
+import { createMockServer, createMockSession } from './helpers.js';
+import { assertDefined } from '../../test-utils.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolDefinition } from '../../../src/tools/definitions.js';
+
+describe('tools/registry', () => {
+	describe('allTools', () => {
+		it('aggregates all 33 tool definitions', () => {
+			expect(allTools.length).toBe(39);
+		});
+
+		it('contains known tools from different files', () => {
+			const names = allTools.map((t) => t.name);
+			expect(names).toContain('wp_connect');
+			expect(names).toContain('wp_read_post');
+			expect(names).toContain('wp_update_block');
+			expect(names).toContain('wp_status');
+			expect(names).toContain('wp_upload_media');
+			expect(names).toContain('wp_list_notes');
+			expect(names).toContain('wp_set_categories');
+			expect(names).toContain('wp_update_command_status');
+		});
+	});
+
+	describe('getToolByName', () => {
+		it('returns a tool definition by name', () => {
+			const tool = getToolByName('wp_read_post');
+			assertDefined(tool);
+			expect(tool.name).toBe('wp_read_post');
+			expect(tool.description).toContain('block listing');
+		});
+
+		it('returns undefined for unknown names', () => {
+			expect(getToolByName('wp_nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getToolsForState', () => {
+		it('returns tools available in disconnected state', () => {
+			const tools = getToolsForState('disconnected');
+			const names = tools.map((t) => t.name);
+			expect(names).toContain('wp_connect');
+			expect(names).toContain('wp_status'); // no availableIn restriction
+			expect(names).not.toContain('wp_read_post'); // editing only
+			expect(names).not.toContain('wp_open_post'); // connected only
+		});
+
+		it('returns tools available in connected state', () => {
+			const tools = getToolsForState('connected');
+			const names = tools.map((t) => t.name);
+			expect(names).toContain('wp_open_post');
+			expect(names).toContain('wp_list_posts');
+			expect(names).toContain('wp_status');
+			expect(names).not.toContain('wp_connect'); // disconnected only
+			expect(names).not.toContain('wp_read_post'); // editing only
+		});
+
+		it('returns tools available in editing state', () => {
+			const tools = getToolsForState('editing');
+			const names = tools.map((t) => t.name);
+			expect(names).toContain('wp_read_post');
+			expect(names).toContain('wp_update_block');
+			expect(names).toContain('wp_status');
+			expect(names).toContain('wp_disconnect');
+			expect(names).not.toContain('wp_connect'); // disconnected only
+		});
+	});
+
+	describe('getToolsByTag', () => {
+		it('returns tools with the editing tag', () => {
+			const tools = getToolsByTag('editing');
+			const names = tools.map((t) => t.name);
+			expect(names).toContain('wp_update_block');
+			expect(names).toContain('wp_insert_block');
+			expect(names).toContain('wp_set_title');
+			expect(names).not.toContain('wp_read_post');
+		});
+
+		it('returns tools with the connection tag', () => {
+			const tools = getToolsByTag('connection');
+			const names = tools.map((t) => t.name);
+			expect(names).toContain('wp_connect');
+			expect(names).toContain('wp_disconnect');
+			expect(names).toHaveLength(2);
+		});
+
+		it('returns empty array for unknown tags', () => {
+			expect(getToolsByTag('nonexistent')).toHaveLength(0);
+		});
+	});
+
+	describe('registerToolDefinitions', () => {
+		it('wraps execute returning string as success content', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => 'Success!',
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe('Success!');
+			expect(result.isError).toBeUndefined();
+		});
+
+		it('wraps execute returning ToolResult with isError', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => ({
+						text: 'Not allowed',
+						isError: true,
+					}),
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe('Not allowed');
+			expect(result.isError).toBe(true);
+		});
+
+		it('catches thrown Error and formats with tool name', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => {
+						throw new Error('Something broke');
+					},
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe(
+				'test_tool failed: Something broke'
+			);
+			expect(result.isError).toBe(true);
+		});
+
+		it('catches non-Error throws and stringifies', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => {
+						// eslint-disable-next-line @typescript-eslint/only-throw-error
+						throw 'raw string error';
+					},
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe(
+				'test_tool failed: raw string error'
+			);
+			expect(result.isError).toBe(true);
+		});
+	});
+
+	describe('registerAllTools', () => {
+		it('registers all tools on the MCP server', () => {
+			const server = createMockServer();
+			const session = createMockSession();
+			registerAllTools(server as unknown as McpServer, session);
+			expect(server.registeredTools.size).toBe(39);
+		});
+	});
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -182,7 +182,7 @@ describe('tools/registry', () => {
 			expect(result.isError).toBe(true);
 		});
 
-		it('catches non-Error throws and stringifies', async () => {
+		it('catches thrown strings and passes them through', async () => {
 			const server = createMockServer();
 			const session = createMockSession();
 
@@ -208,6 +208,36 @@ describe('tools/registry', () => {
 			const result = await registered.handler({});
 			expect(result.content[0].text).toBe(
 				'test_tool failed: raw string error'
+			);
+			expect(result.isError).toBe(true);
+		});
+
+		it('catches thrown objects and JSON-serializes them', async () => {
+			const server = createMockServer();
+			const session = createMockSession();
+
+			const tools: ToolDefinition[] = [
+				{
+					name: 'test_tool',
+					description: 'A test tool',
+					execute: () => {
+						// eslint-disable-next-line @typescript-eslint/only-throw-error
+						throw { code: 'ENOENT', path: '/tmp/missing' };
+					},
+				},
+			];
+
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				tools
+			);
+
+			const registered = server.registeredTools.get('test_tool');
+			assertDefined(registered);
+			const result = await registered.handler({});
+			expect(result.content[0].text).toBe(
+				'test_tool failed: {"code":"ENOENT","path":"/tmp/missing"}'
 			);
 			expect(result.isError).toBe(true);
 		});

--- a/tests/unit/tools/status.test.ts
+++ b/tests/unit/tools/status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { registerStatusTools } from '../../../src/tools/status.js';
+import { statusTools } from '../../../src/tools/status.js';
+import { registerToolDefinitions } from '../../../src/tools/registry.js';
 import {
 	createMockServer,
 	createMockSession,
@@ -43,7 +44,11 @@ describe('status tools', () => {
 
 	it('registers wp_status, wp_collaborators, and wp_save', () => {
 		const session = createMockSession();
-		registerStatusTools(server as unknown as McpServer, session);
+		registerToolDefinitions(
+			server as unknown as McpServer,
+			session,
+			statusTools
+		);
 
 		expect(server.registeredTools.has('wp_status')).toBe(true);
 		expect(server.registeredTools.has('wp_collaborators')).toBe(true);
@@ -53,7 +58,11 @@ describe('status tools', () => {
 	describe('wp_status', () => {
 		it('shows disconnected state', async () => {
 			const session = createMockSession({ state: 'disconnected' });
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -70,7 +79,11 @@ describe('status tools', () => {
 				state: 'connected',
 				user: fakeUser,
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -93,7 +106,11 @@ describe('status tools', () => {
 				},
 				collaborators: [fakeCollaborator],
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -117,7 +134,11 @@ describe('status tools', () => {
 				post: fakePost,
 				postGone: { gone: true, reason: 'This post has been deleted.' },
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -142,7 +163,11 @@ describe('status tools', () => {
 					transport: 'sse',
 				},
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -166,7 +191,11 @@ describe('status tools', () => {
 						'Plugin protocol v99 is not compatible with this MCP server (supports v1). Update the MCP server.',
 				},
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -189,7 +218,11 @@ describe('status tools', () => {
 					transport: 'sse',
 				},
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -216,7 +249,11 @@ describe('status tools', () => {
 					transport: 'sse',
 					protocolWarning: null,
 				});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -236,7 +273,11 @@ describe('status tools', () => {
 					transport: 'sse',
 				},
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -251,7 +292,11 @@ describe('status tools', () => {
 				user: fakeUser,
 				pluginInfo: null,
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -292,7 +337,11 @@ describe('status tools', () => {
 					transport: 'sse',
 					protocolWarning: null,
 				}); // after detection
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -323,7 +372,11 @@ describe('status tools', () => {
 			(
 				session.activateEditorPlugin as ReturnType<typeof vi.fn>
 			).mockRejectedValue(new WordPressApiError('Forbidden', 403, ''));
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -348,7 +401,11 @@ describe('status tools', () => {
 				version: '0.0.1',
 				pluginFile: 'claudaborative-editing/claudaborative-editing',
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -387,7 +444,11 @@ describe('status tools', () => {
 					transport: 'sse',
 					protocolWarning: null,
 				});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -416,7 +477,11 @@ describe('status tools', () => {
 			(
 				session.installEditorPlugin as ReturnType<typeof vi.fn>
 			).mockRejectedValue(new WordPressApiError('Not Found', 404, ''));
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -435,7 +500,11 @@ describe('status tools', () => {
 			(
 				session.getEditorPluginInstallStatus as ReturnType<typeof vi.fn>
 			).mockRejectedValue(new WordPressApiError('Forbidden', 403, ''));
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -464,7 +533,11 @@ describe('status tools', () => {
 			).mockRejectedValue(
 				new WordPressApiError('Internal Server Error', 500, '')
 			);
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -488,7 +561,11 @@ describe('status tools', () => {
 			(
 				session.getTitle as ReturnType<typeof import('vitest').vi.fn>
 			).mockReturnValue('Updated Title');
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_status');
 			assertDefined(tool);
@@ -509,7 +586,11 @@ describe('status tools', () => {
 				post: fakePost,
 				collaborators: [fakeCollaborator],
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_collaborators');
 			assertDefined(tool);
@@ -528,7 +609,11 @@ describe('status tools', () => {
 				post: fakePost,
 				collaborators: [],
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_collaborators');
 			assertDefined(tool);
@@ -552,7 +637,11 @@ describe('status tools', () => {
 			).mockImplementation(() => {
 				throw new Error('unexpected');
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_collaborators');
 			assertDefined(tool);
@@ -560,7 +649,7 @@ describe('status tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain(
-				'Failed to get collaborators: unexpected'
+				'wp_collaborators failed: unexpected'
 			);
 		});
 
@@ -569,7 +658,11 @@ describe('status tools', () => {
 				state: 'connected',
 				user: fakeUser,
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_collaborators');
 			assertDefined(tool);
@@ -589,7 +682,11 @@ describe('status tools', () => {
 				user: fakeUser,
 				post: fakePost,
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_save');
 			assertDefined(tool);
@@ -610,7 +707,11 @@ describe('status tools', () => {
 			(
 				session.getTitle as ReturnType<typeof import('vitest').vi.fn>
 			).mockReturnValue('Updated Title');
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_save');
 			assertDefined(tool);
@@ -631,14 +732,18 @@ describe('status tools', () => {
 					"Operation requires state editing, but current state is 'disconnected'"
 				);
 			});
-			registerStatusTools(server as unknown as McpServer, session);
+			registerToolDefinitions(
+				server as unknown as McpServer,
+				session,
+				statusTools
+			);
 
 			const tool = server.registeredTools.get('wp_save');
 			assertDefined(tool);
 			const result = await tool.handler({});
 
 			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain('Failed to save');
+			expect(result.content[0].text).toContain('wp_save failed');
 		});
 	});
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,19 +5,49 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as {
 	version: string;
 };
 
-export default defineConfig({
-	entry: ['src/index.ts'],
+const shared: {
+	format: ['esm'];
+	target: 'node20';
+	outDir: string;
+	sourcemap: boolean;
+	dts: boolean;
+	define: Record<string, string>;
+} = {
 	format: ['esm'],
 	target: 'node20',
 	outDir: 'dist',
-	clean: true,
 	sourcemap: true,
 	dts: true,
-	splitting: false,
-	banner: {
-		js: '#!/usr/bin/env node',
-	},
 	define: {
 		__PKG_VERSION__: JSON.stringify(pkg.version),
 	},
-});
+};
+
+export default defineConfig([
+	// CLI entry (single bundle with shebang)
+	{
+		...shared,
+		entry: ['src/index.ts'],
+		clean: true,
+		splitting: false,
+		banner: {
+			js: '#!/usr/bin/env node',
+		},
+	},
+	// Library entries (importable subpath exports, no shebang)
+	{
+		...shared,
+		entry: {
+			'tools/definitions': 'src/tools/definitions.ts',
+			'tools/registry': 'src/tools/registry.ts',
+			'prompts/definitions': 'src/prompts/definitions.ts',
+			'prompts/registry': 'src/prompts/registry.ts',
+			'prompts/prompt-content': 'src/prompts/prompt-content.ts',
+			'session/session-manager': 'src/session/session-manager.ts',
+			'server-instructions': 'src/server-instructions.ts',
+			'shared/commands': 'shared/commands.ts',
+		},
+		clean: false,
+		splitting: false,
+	},
+]);


### PR DESCRIPTION
## Summary

- Decouples tool/prompt definitions from the MCP SDK so they can be consumed by an external hosted orchestrator
- Each tool file now exports a `ToolDefinition[]` array with `execute(session, input)` that returns `string | ToolResult | throws`
- Each prompt file exports a `PromptDefinition[]` array with `buildMessages(session, args)` returning simplified messages
- Registries (`src/tools/registry.ts`, `src/prompts/registry.ts`) aggregate definitions and provide MCP wiring + lookup helpers (`getToolByName`, `getToolsForState`, `getToolsByTag`)
- Channel instructions extracted to `src/server-instructions.ts` as pure functions
- `server.ts` simplified from 15 register calls to 2
- Multi-entry tsup build emits library entry points with `.d.ts` files
- 8 subpath exports added to `package.json` for external consumption

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 1164/1164 tests passing
- [x] `npm run build` — all entry points build with declarations
- [x] `npm run lint` — ESLint + Prettier + markdownlint clean
- [ ] Smoke test against WordPress dev site (connect, open post, edit, notes, commands)