### PR TITLE
Show onboarding help when disconnected, add claudaborative.cloud option

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -197,7 +197,17 @@ export async function runSetup(
 	await configureClients(deps, credentials, selectedClients);
 
 	deps.log('');
-	deps.log('Done! Restart Claude Code to start editing.');
+	deps.log("Done! Here's what to do next:");
+	deps.log('');
+	deps.log('  1. Restart Claude Code to load the new configuration.');
+	deps.log('  2. Open a post in your WordPress editor.');
+	deps.log('     The sparkle icon will turn orange when connected.');
+	deps.log('  3. Use the sparkle menu in the toolbar to start editing!');
+	deps.log('');
+	deps.log(
+		'Tip: You can also try the hosted service at claudaborative.cloud'
+	);
+	deps.log('     \u2014 no local setup needed.');
 
 	deps.cleanup();
 }

--- a/tests/unit/cli/setup.test.ts
+++ b/tests/unit/cli/setup.test.ts
@@ -188,9 +188,10 @@ describe('setup wizard', () => {
 			expect(output).toContain(
 				'Collaborative editing endpoint available'
 			);
-			expect(output).toContain(
-				'Done! Restart Claude Code to start editing.'
-			);
+			expect(output).toContain("Done! Here's what to do next:");
+			expect(output).toContain('Restart Claude Code');
+			expect(output).toContain('sparkle icon will turn orange');
+			expect(output).toContain('claudaborative.cloud');
 			expect(writeConfig).toHaveBeenCalledTimes(1);
 		});
 

--- a/wordpress-plugin/src/components/AiActionsMenu/index.tsx
+++ b/wordpress-plugin/src/components/AiActionsMenu/index.tsx
@@ -10,7 +10,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -28,6 +33,7 @@ import type { CommandSlug } from '#shared/commands';
 import SparkleIcon from '../SparkleIcon';
 import EditFocusModal from '../EditFocusModal';
 import TranslateModal from '../TranslateModal';
+import SetupModal from '../SetupModal';
 import aiActionsStore from '../../store';
 
 import './style.scss';
@@ -79,6 +85,7 @@ export default function AiActionsMenu() {
 
 	const [editModalOpen, setEditModalOpen] = useState(false);
 	const [translateModalOpen, setTranslateModalOpen] = useState(false);
+	const [setupModalOpen, setSetupModalOpen] = useState(false);
 
 	return (
 		<>
@@ -165,6 +172,33 @@ export default function AiActionsMenu() {
 										)}
 									</MenuItem>
 								</MenuGroup>
+								{!mcpConnected && (
+									<MenuGroup>
+										<div className="wpce-ai-actions-disconnected-notice">
+											<div className="wpce-ai-actions-disconnected-status">
+												<span className="wpce-ai-actions-disconnected-dot" />
+												{__(
+													'Not connected',
+													'claudaborative-editing'
+												)}
+											</div>
+											<Button
+												className="wpce-ai-actions-setup-button"
+												variant="secondary"
+												size="compact"
+												onClick={() => {
+													onClose();
+													setSetupModalOpen(true);
+												}}
+											>
+												{__(
+													'Get started',
+													'claudaborative-editing'
+												)}
+											</Button>
+										</div>
+									</MenuGroup>
+								)}
 							</>
 						);
 					}}
@@ -189,6 +223,9 @@ export default function AiActionsMenu() {
 					}}
 					onRequestClose={() => setTranslateModalOpen(false)}
 				/>
+			)}
+			{setupModalOpen && (
+				<SetupModal onRequestClose={() => setSetupModalOpen(false)} />
 			)}
 		</>
 	);

--- a/wordpress-plugin/src/components/AiActionsMenu/style.scss
+++ b/wordpress-plugin/src/components/AiActionsMenu/style.scss
@@ -1,3 +1,32 @@
 .claudaborative-editing-ai-actions-menu {
 	width: 300px;
 }
+
+.wpce-ai-actions-disconnected-notice {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 6px 8px;
+}
+
+.wpce-ai-actions-disconnected-status {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: #757575;
+}
+
+.wpce-ai-actions-disconnected-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #cc1818;
+	flex-shrink: 0;
+}
+
+.wpce-ai-actions-setup-button.components-button {
+	font-size: 12px;
+	flex-shrink: 0;
+}

--- a/wordpress-plugin/src/components/AiActionsMenu/test/index.test.tsx
+++ b/wordpress-plugin/src/components/AiActionsMenu/test/index.test.tsx
@@ -8,16 +8,26 @@ jest.mock('@wordpress/data', () => ({
 
 jest.mock('@wordpress/notices', () => ({ store: { name: 'core/notices' } }));
 
+const mockOnClose = jest.fn();
+
 jest.mock('@wordpress/components', () => {
 	const { createElement } = require('react');
 	return {
+		Button: ({
+			children,
+			onClick,
+			className,
+			variant: _v,
+			...props
+		}: any) =>
+			createElement('button', { onClick, className, ...props }, children),
 		DropdownMenu: ({ children, icon, label }: any) =>
 			createElement(
 				'div',
 				{ 'data-testid': 'dropdown-menu', 'aria-label': label },
 				createElement('span', { 'data-testid': 'menu-icon' }, icon),
 				typeof children === 'function'
-					? children({ onClose: jest.fn() })
+					? children({ onClose: mockOnClose })
 					: children
 			),
 		MenuGroup: ({ children }: any) =>
@@ -118,6 +128,26 @@ jest.mock('../../TranslateModal', () => {
 						onClick: onRequestClose,
 					},
 					'Close Translate'
+				)
+			),
+	};
+});
+
+jest.mock('../../SetupModal', () => {
+	const { createElement } = require('react');
+	return {
+		__esModule: true,
+		default: ({ onRequestClose }: { onRequestClose: () => void }) =>
+			createElement(
+				'div',
+				{ 'data-testid': 'setup-modal' },
+				createElement(
+					'button',
+					{
+						'data-testid': 'setup-modal-close',
+						onClick: onRequestClose,
+					},
+					'Close Setup'
 				)
 			),
 	};
@@ -468,5 +498,57 @@ describe('AiActionsMenu', () => {
 			'Something went wrong',
 			{ type: 'snackbar' }
 		);
+	});
+
+	it('shows disconnected notice when not connected', () => {
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: false,
+			mcpLastSeenAt: null,
+			isLoading: false,
+			error: null,
+		});
+
+		render(<AiActionsMenu />);
+		expect(screen.getByText('Not connected')).toBeTruthy();
+		expect(screen.getByText('Get started')).toBeTruthy();
+	});
+
+	it('does not show disconnected notice when connected', () => {
+		render(<AiActionsMenu />);
+		expect(screen.queryByText('Not connected')).toBeNull();
+		expect(screen.queryByText('Get started')).toBeNull();
+	});
+
+	it('clicking get started opens setup modal', () => {
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: false,
+			mcpLastSeenAt: null,
+			isLoading: false,
+			error: null,
+		});
+
+		render(<AiActionsMenu />);
+		expect(screen.queryByTestId('setup-modal')).toBeNull();
+
+		fireEvent.click(screen.getByText('Get started'));
+
+		expect(mockOnClose).toHaveBeenCalled();
+		expect(screen.getByTestId('setup-modal')).toBeTruthy();
+	});
+
+	it('setup modal close hides the modal', () => {
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: false,
+			mcpLastSeenAt: null,
+			isLoading: false,
+			error: null,
+		});
+
+		render(<AiActionsMenu />);
+		fireEvent.click(screen.getByText('Get started'));
+		expect(screen.getByTestId('setup-modal')).toBeTruthy();
+
+		fireEvent.click(screen.getByTestId('setup-modal-close'));
+		expect(screen.queryByTestId('setup-modal')).toBeNull();
 	});
 });

--- a/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
@@ -10,12 +10,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button, ExternalLink, Icon } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
 import { cloud, code } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
 // Styles are imported via ConnectionStatus/style.scss to ensure
 // they land in the extracted style-index.css stylesheet.
 
@@ -29,21 +29,7 @@ const SETUP_COMMAND = 'npx claudaborative-editing start';
  * @return Rendered onboarding content.
  */
 export default function OnboardingContent() {
-	const [copied, setCopied] = useState(false);
-
-	const handleCopy = useCallback(() => {
-		navigator.clipboard.writeText(SETUP_COMMAND).then(
-			() => {
-				setCopied(true);
-				setTimeout(() => setCopied(false), 2000);
-			},
-			() => {
-				// Clipboard API unavailable (e.g., HTTP-only local dev).
-				// The <code> element has user-select: all, so users can
-				// still select and copy manually.
-			}
-		);
-	}, []);
+	const { copied, handleCopy } = useCopyToClipboard(SETUP_COMMAND);
 
 	return (
 		<div className="wpce-onboarding">

--- a/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
@@ -16,10 +16,9 @@ import { cloud, code } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
+import { SETUP_COMMAND } from '../../constants';
 // Styles are imported via ConnectionStatus/style.scss to ensure
 // they land in the extracted style-index.css stylesheet.
-
-const SETUP_COMMAND = 'npx claudaborative-editing start';
 
 /**
  * OnboardingContent component.

--- a/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
@@ -1,0 +1,112 @@
+/**
+ * Onboarding content shown in the ConnectionStatus popover when disconnected.
+ *
+ * Presents two setup paths: Claudaborative Cloud (hosted) and local
+ * setup via Claude Code CLI.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, ExternalLink, Icon } from '@wordpress/components';
+import { useState, useCallback } from '@wordpress/element';
+import { cloud, code } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+// Styles are imported via ConnectionStatus/style.scss to ensure
+// they land in the extracted style-index.css stylesheet.
+
+const SETUP_COMMAND = 'npx claudaborative-editing start';
+
+/**
+ * OnboardingContent component.
+ *
+ * Renders two setup option cards: hosted cloud service and local CLI setup.
+ *
+ * @return Rendered onboarding content.
+ */
+export default function OnboardingContent() {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = useCallback(() => {
+		navigator.clipboard.writeText(SETUP_COMMAND).then(
+			() => {
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			},
+			() => {
+				// Clipboard API unavailable (e.g., HTTP-only local dev).
+				// The <code> element has user-select: all, so users can
+				// still select and copy manually.
+			}
+		);
+	}, []);
+
+	return (
+		<div className="wpce-onboarding">
+			<div className="wpce-onboarding-heading">
+				{__(
+					'Get started with one of these options:',
+					'claudaborative-editing'
+				)}
+			</div>
+
+			<div className="wpce-onboarding-option wpce-onboarding-option-cloud">
+				<div className="wpce-onboarding-option-header">
+					<Icon icon={cloud} size={20} />
+					<span className="wpce-onboarding-option-title">
+						{__('Claudaborative Cloud', 'claudaborative-editing')}
+					</span>
+				</div>
+				<p className="wpce-onboarding-option-description">
+					{__(
+						'The fastest way to get started. No local setup required.',
+						'claudaborative-editing'
+					)}
+				</p>
+				<ExternalLink
+					className="wpce-onboarding-cloud-link"
+					href="https://claudaborative.cloud"
+				>
+					{__(
+						'Sign up at claudaborative.cloud',
+						'claudaborative-editing'
+					)}
+				</ExternalLink>
+			</div>
+
+			<div className="wpce-onboarding-option">
+				<div className="wpce-onboarding-option-header">
+					<Icon icon={code} size={20} />
+					<span className="wpce-onboarding-option-title">
+						{__('Set up locally', 'claudaborative-editing')}
+					</span>
+				</div>
+				<p className="wpce-onboarding-option-description">
+					{__(
+						'Use Claude Code on your own computer.',
+						'claudaborative-editing'
+					)}
+				</p>
+				<div className="wpce-onboarding-command-row">
+					<code className="wpce-onboarding-command">
+						{SETUP_COMMAND}
+					</code>
+					<Button
+						className="wpce-onboarding-copy-button"
+						variant="tertiary"
+						size="small"
+						onClick={handleCopy}
+					>
+						{copied
+							? __('Copied!', 'claudaborative-editing')
+							: __('Copy', 'claudaborative-editing')}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -138,13 +138,7 @@ export default function ConnectionStatus() {
 
 		const check = (): void => {
 			const el = document.querySelector(selector);
-			setFooterEl((prev) => {
-				if (!el && prev) {
-					// Footer disappeared — dismiss any open popover.
-					setShowPopover(false);
-				}
-				return el || null;
-			});
+			setFooterEl(el || null);
 		};
 
 		check();
@@ -154,6 +148,15 @@ export default function ConnectionStatus() {
 
 		return () => observer.disconnect();
 	}, []);
+
+	// Close popover when footer element disappears (e.g., distraction-free mode).
+	const prevFooterRef = useRef<Element | null>(null);
+	useEffect(() => {
+		if (!footerEl && prevFooterRef.current) {
+			setShowPopover(false);
+		}
+		prevFooterRef.current = footerEl;
+	}, [footerEl]);
 
 	// Build tooltip content (computed every render, no early return above).
 	const statusLines: string[] = [];

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -233,7 +233,7 @@ export default function ConnectionStatus() {
 					<div
 						className={
 							'wpce-footer-status-tooltip' +
-							(!mcpConnected
+							(!mcpConnected && !wasConnectedRef.current
 								? ' wpce-footer-status-tooltip-onboarding'
 								: '')
 						}

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -30,6 +30,7 @@ import { useCommands } from '../../hooks/use-commands';
 import { getCommandProgressLabel } from '../../utils/command-i18n';
 import aiActionsStore from '../../store';
 import SparkleIcon from '../SparkleIcon';
+import OnboardingContent from './OnboardingContent';
 
 import './style.scss';
 
@@ -117,6 +118,15 @@ export default function ConnectionStatus() {
 		[isEditingOtherPost, activeCommand?.post_id]
 	);
 
+	// Track whether MCP was ever connected during this editor session.
+	// Used to distinguish first-time setup from temporary disconnections.
+	const wasConnectedRef = useRef<boolean>(false);
+	useEffect(() => {
+		if (mcpConnected) {
+			wasConnectedRef.current = true;
+		}
+	}, [mcpConnected]);
+
 	const [footerEl, setFooterEl] = useState<Element | null>(null);
 	const [showPopover, setShowPopover] = useState<boolean>(false);
 
@@ -128,7 +138,13 @@ export default function ConnectionStatus() {
 
 		const check = (): void => {
 			const el = document.querySelector(selector);
-			setFooterEl(el || null);
+			setFooterEl((prev) => {
+				if (!el && prev) {
+					// Footer disappeared — dismiss any open popover.
+					setShowPopover(false);
+				}
+				return el || null;
+			});
 		};
 
 		check();
@@ -211,13 +227,28 @@ export default function ConnectionStatus() {
 					constrainTabbing={false}
 					className="wpce-footer-status-popover"
 				>
-					<div className="wpce-footer-status-tooltip">
+					<div
+						className={
+							'wpce-footer-status-tooltip' +
+							(!mcpConnected
+								? ' wpce-footer-status-tooltip-onboarding'
+								: '')
+						}
+					>
 						<div className="wpce-footer-status-title">
 							{__(
 								'Claudaborative Editing',
 								'claudaborative-editing'
 							)}
 						</div>
+						{!mcpConnected && wasConnectedRef.current && (
+							<div className="wpce-footer-status-line wpce-footer-status-reconnecting">
+								{__(
+									'Reconnecting\u2026',
+									'claudaborative-editing'
+								)}
+							</div>
+						)}
 						{statusLines.map((line, i) => (
 							<div key={i} className="wpce-footer-status-line">
 								{line}
@@ -242,6 +273,9 @@ export default function ConnectionStatus() {
 									)}
 							</div>
 						))}
+						{!mcpConnected && !wasConnectedRef.current && (
+							<OnboardingContent />
+						)}
 					</div>
 				</Popover>
 			)}

--- a/wordpress-plugin/src/components/ConnectionStatus/style.scss
+++ b/wordpress-plugin/src/components/ConnectionStatus/style.scss
@@ -49,3 +49,95 @@
 	height: auto;
 	vertical-align: baseline;
 }
+
+.wpce-footer-status-tooltip-onboarding {
+	white-space: normal;
+	min-width: 300px;
+	max-width: 350px;
+}
+
+.wpce-footer-status-reconnecting {
+	color: #d97706;
+	font-style: italic;
+}
+
+// Onboarding content shown in the popover when disconnected.
+
+.wpce-onboarding {
+	padding: 4px 0 0;
+}
+
+.wpce-onboarding-heading {
+	font-size: 12px;
+	color: #757575;
+	margin-bottom: 8px;
+}
+
+.wpce-onboarding-option {
+	padding: 8px;
+	border-radius: 4px;
+
+	& + & {
+		margin-top: 6px;
+	}
+}
+
+.wpce-onboarding-option-cloud {
+	background: #fffbf0;
+	border: 1px solid #d97706;
+}
+
+.wpce-onboarding-option-header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-bottom: 4px;
+}
+
+// The Icon component renders an SVG inside a wrapper span;
+// fix the wrapper so it doesn't add extra height.
+// stylelint-disable-next-line no-descending-specificity
+.wpce-onboarding-option-header svg {
+	fill: #1e1e1e;
+	display: block;
+}
+
+.wpce-onboarding-option-title {
+	font-weight: 600;
+	font-size: 12px;
+}
+
+.wpce-onboarding-option-description {
+	font-size: 12px;
+	color: #757575;
+	margin: 0 0 6px;
+	line-height: 1.4;
+}
+
+.wpce-onboarding-cloud-link {
+	font-size: 12px;
+}
+
+.wpce-onboarding-command-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.wpce-onboarding-command {
+	font-size: 11px;
+	background: #f0f0f0;
+	padding: 3px 6px;
+	border-radius: 2px;
+	user-select: all;
+	flex: 1;
+	min-width: 0;
+}
+
+.wpce-onboarding-copy-button.components-button {
+	font-size: 11px;
+	padding: 2px 8px;
+	min-height: 0;
+	height: auto;
+	flex-shrink: 0;
+}

--- a/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
@@ -1,3 +1,11 @@
+const mockHandleCopy = jest.fn();
+jest.mock('../../../hooks/use-copy-to-clipboard', () => ({
+	useCopyToClipboard: jest.fn(() => ({
+		copied: false,
+		handleCopy: mockHandleCopy,
+	})),
+}));
+
 jest.mock('@wordpress/i18n', () => ({
 	__: (str: string) => str,
 	sprintf: (fmt: string, ...args: string[]) => {
@@ -41,22 +49,19 @@ jest.mock('@wordpress/icons', () => ({
 	code: { name: 'code' },
 }));
 
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useCopyToClipboard } from '../../../hooks/use-copy-to-clipboard';
 import OnboardingContent from '../OnboardingContent';
 
+const mockedUseCopyToClipboard = useCopyToClipboard as jest.Mock;
+
 describe('OnboardingContent', () => {
-	let clipboardSpy: jest.SpyInstance;
-
 	beforeEach(() => {
-		jest.useFakeTimers();
-		clipboardSpy = jest.fn().mockResolvedValue(undefined);
-		Object.assign(navigator, {
-			clipboard: { writeText: clipboardSpy },
+		jest.clearAllMocks();
+		mockedUseCopyToClipboard.mockReturnValue({
+			copied: false,
+			handleCopy: mockHandleCopy,
 		});
-	});
-
-	afterEach(() => {
-		jest.useRealTimers();
 	});
 
 	it('renders the heading text', () => {
@@ -92,42 +97,24 @@ describe('OnboardingContent', () => {
 		).toBeTruthy();
 	});
 
-	it('copy button copies the setup command to clipboard', async () => {
+	it('copy button calls handleCopy from useCopyToClipboard', () => {
 		render(<OnboardingContent />);
 
 		const copyButton = screen.getByText('Copy');
-		await act(async () => fireEvent.click(copyButton));
+		fireEvent.click(copyButton);
 
-		expect(clipboardSpy).toHaveBeenCalledWith(
-			'npx claudaborative-editing start'
-		);
+		expect(mockHandleCopy).toHaveBeenCalled();
 	});
 
-	it('does not throw when clipboard write fails', async () => {
-		clipboardSpy.mockRejectedValueOnce(new Error('Not allowed'));
+	it('copy button shows "Copied!" feedback when copied is true', () => {
+		mockedUseCopyToClipboard.mockReturnValue({
+			copied: true,
+			handleCopy: mockHandleCopy,
+		});
 
 		render(<OnboardingContent />);
-
-		const copyButton = screen.getByText('Copy');
-		await act(async () => fireEvent.click(copyButton));
-
-		// Button should still show "Copy" (not "Copied!") since write failed.
-		expect(screen.getByText('Copy')).toBeTruthy();
-	});
-
-	it('copy button shows "Copied!" feedback after click', async () => {
-		render(<OnboardingContent />);
-
-		const copyButton = screen.getByText('Copy');
-		await act(async () => fireEvent.click(copyButton));
 
 		expect(screen.getByText('Copied!')).toBeTruthy();
 		expect(screen.queryByText('Copy')).toBeNull();
-
-		// After 2 seconds, reverts to "Copy"
-		act(() => jest.advanceTimersByTime(2000));
-
-		expect(screen.getByText('Copy')).toBeTruthy();
-		expect(screen.queryByText('Copied!')).toBeNull();
 	});
 });

--- a/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
@@ -1,0 +1,133 @@
+jest.mock('@wordpress/i18n', () => ({
+	__: (str: string) => str,
+	sprintf: (fmt: string, ...args: string[]) => {
+		let result = fmt;
+		for (const arg of args) {
+			result = result.replace('%s', arg);
+		}
+		return result;
+	},
+}));
+
+jest.mock('@wordpress/components', () => {
+	const { createElement } = require('react');
+	return {
+		Button: ({
+			children,
+			onClick,
+			className,
+			variant: _v,
+			size: _s,
+			...props
+		}: any) =>
+			createElement('button', { onClick, className, ...props }, children),
+		ExternalLink: ({ children, href, className, ...props }: any) =>
+			createElement(
+				'a',
+				{ href, target: '_blank', className, ...props },
+				children
+			),
+		Icon: ({ icon, size }: any) =>
+			createElement('span', {
+				'data-testid': 'icon',
+				'data-icon': icon?.name ?? 'unknown',
+				'data-size': size,
+			}),
+	};
+});
+
+jest.mock('@wordpress/icons', () => ({
+	cloud: { name: 'cloud' },
+	code: { name: 'code' },
+}));
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import OnboardingContent from '../OnboardingContent';
+
+describe('OnboardingContent', () => {
+	let clipboardSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		clipboardSpy = jest.fn().mockResolvedValue(undefined);
+		Object.assign(navigator, {
+			clipboard: { writeText: clipboardSpy },
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('renders the heading text', () => {
+		render(<OnboardingContent />);
+		expect(
+			screen.getByText('Get started with one of these options:')
+		).toBeTruthy();
+	});
+
+	it('renders cloud option with link to claudaborative.cloud', () => {
+		render(<OnboardingContent />);
+		expect(screen.getByText('Claudaborative Cloud')).toBeTruthy();
+		expect(
+			screen.getByText(
+				'The fastest way to get started. No local setup required.'
+			)
+		).toBeTruthy();
+
+		const link = screen.getByText('Sign up at claudaborative.cloud');
+		expect(link.tagName).toBe('A');
+		expect(link.getAttribute('href')).toBe('https://claudaborative.cloud');
+		expect(link.getAttribute('target')).toBe('_blank');
+	});
+
+	it('renders local setup option with command text', () => {
+		render(<OnboardingContent />);
+		expect(screen.getByText('Set up locally')).toBeTruthy();
+		expect(
+			screen.getByText('Use Claude Code on your own computer.')
+		).toBeTruthy();
+		expect(
+			screen.getByText('npx claudaborative-editing start')
+		).toBeTruthy();
+	});
+
+	it('copy button copies the setup command to clipboard', async () => {
+		render(<OnboardingContent />);
+
+		const copyButton = screen.getByText('Copy');
+		await act(async () => fireEvent.click(copyButton));
+
+		expect(clipboardSpy).toHaveBeenCalledWith(
+			'npx claudaborative-editing start'
+		);
+	});
+
+	it('does not throw when clipboard write fails', async () => {
+		clipboardSpy.mockRejectedValueOnce(new Error('Not allowed'));
+
+		render(<OnboardingContent />);
+
+		const copyButton = screen.getByText('Copy');
+		await act(async () => fireEvent.click(copyButton));
+
+		// Button should still show "Copy" (not "Copied!") since write failed.
+		expect(screen.getByText('Copy')).toBeTruthy();
+	});
+
+	it('copy button shows "Copied!" feedback after click', async () => {
+		render(<OnboardingContent />);
+
+		const copyButton = screen.getByText('Copy');
+		await act(async () => fireEvent.click(copyButton));
+
+		expect(screen.getByText('Copied!')).toBeTruthy();
+		expect(screen.queryByText('Copy')).toBeNull();
+
+		// After 2 seconds, reverts to "Copy"
+		act(() => jest.advanceTimersByTime(2000));
+
+		expect(screen.getByText('Copy')).toBeTruthy();
+		expect(screen.queryByText('Copied!')).toBeNull();
+	});
+});

--- a/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
@@ -629,6 +629,42 @@ describe('ConnectionStatus', () => {
 		expect(screen.queryByText('Reconnecting\u2026')).toBeNull();
 	});
 
+	it('closes popover when footer element is removed', async () => {
+		// Replace stub with an observer that captures its callback so we
+		// can invoke it synchronously inside act().
+		let observerCallback: MutationCallback | null = null;
+		const savedMO = window.MutationObserver;
+		window.MutationObserver = class {
+			constructor(cb: MutationCallback) {
+				observerCallback = cb;
+			}
+			observe() {}
+			disconnect() {}
+			takeRecords() {
+				return [];
+			}
+		} as any;
+
+		await act(async () => render(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+		expect(screen.getByTestId('popover')).toBeTruthy();
+
+		// Remove footer, then fire the observer callback inside act()
+		// so React processes the resulting state updates synchronously.
+		document.body.removeChild(footerEl);
+		await act(async () => {
+			observerCallback!([], null as any);
+		});
+
+		expect(screen.queryByTestId('popover')).toBeNull();
+
+		// Restore and re-add footer for cleanup
+		window.MutationObserver = savedMO;
+		document.body.appendChild(footerEl);
+	});
+
 	it('popover has onboarding modifier class when disconnected', async () => {
 		await act(async () => render(<ConnectionStatus />));
 

--- a/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
@@ -22,6 +22,7 @@ jest.mock('@wordpress/components', () => {
 			label,
 			isDestructive: _,
 			variant: _v,
+			size: _sz,
 			...props
 		}: any) =>
 			createElement(
@@ -35,8 +36,25 @@ jest.mock('@wordpress/components', () => {
 				{ 'data-testid': 'popover', className },
 				children
 			),
+		ExternalLink: ({ children, href, className, ...props }: any) =>
+			createElement(
+				'a',
+				{ href, target: '_blank', className, ...props },
+				children
+			),
+		Icon: ({ icon, size }: any) =>
+			createElement('span', {
+				'data-testid': 'icon',
+				'data-icon': icon?.name ?? 'unknown',
+				'data-size': size,
+			}),
 	};
 });
+
+jest.mock('@wordpress/icons', () => ({
+	cloud: { name: 'cloud' },
+	code: { name: 'code' },
+}));
 
 jest.mock('../../../hooks/use-mcp-status', () => ({
 	useMcpStatus: jest.fn(),
@@ -529,5 +547,97 @@ describe('ConnectionStatus', () => {
 
 		// Re-add so afterEach cleanup doesn't fail
 		document.body.appendChild(footerEl);
+	});
+
+	it('shows onboarding content when disconnected', async () => {
+		await act(async () => render(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+
+		// Status line should still be present
+		expect(screen.getByText('Status: disconnected')).toBeTruthy();
+
+		// Onboarding content should be visible
+		expect(
+			screen.getByText('Get started with one of these options:')
+		).toBeTruthy();
+		expect(
+			screen.getByText('Sign up at claudaborative.cloud')
+		).toBeTruthy();
+		expect(
+			screen.getByText('npx claudaborative-editing start')
+		).toBeTruthy();
+	});
+
+	it('does not show onboarding content when connected', async () => {
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: true,
+			mcpLastSeenAt: '2026-03-30T12:00:00Z',
+			isLoading: false,
+			error: null,
+		});
+
+		await act(async () => render(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+
+		expect(
+			screen.queryByText('Get started with one of these options:')
+		).toBeNull();
+	});
+
+	it('shows "Reconnecting" when previously connected then disconnected', async () => {
+		// Start connected
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: true,
+			mcpLastSeenAt: '2026-03-30T12:00:00Z',
+			isLoading: false,
+			error: null,
+		});
+
+		const { rerender } = render(<ConnectionStatus />);
+
+		// Transition to disconnected
+		mockedUseMcpStatus.mockReturnValue({
+			mcpConnected: false,
+			mcpLastSeenAt: null,
+			isLoading: false,
+			error: null,
+		});
+
+		await act(async () => rerender(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+
+		expect(screen.getByText('Reconnecting\u2026')).toBeTruthy();
+
+		// Onboarding should NOT be shown during reconnection
+		expect(
+			screen.queryByText('Get started with one of these options:')
+		).toBeNull();
+	});
+
+	it('does not show "Reconnecting" on first load when never connected', async () => {
+		await act(async () => render(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+
+		expect(screen.queryByText('Reconnecting\u2026')).toBeNull();
+	});
+
+	it('popover has onboarding modifier class when disconnected', async () => {
+		await act(async () => render(<ConnectionStatus />));
+
+		const toggle = footerEl.querySelector('.wpce-footer-status-toggle')!;
+		await act(async () => fireEvent.click(toggle));
+
+		const tooltip = screen
+			.getByTestId('popover')
+			.querySelector('.wpce-footer-status-tooltip-onboarding');
+		expect(tooltip).toBeTruthy();
 	});
 });

--- a/wordpress-plugin/src/components/SetupModal/index.tsx
+++ b/wordpress-plugin/src/components/SetupModal/index.tsx
@@ -1,0 +1,172 @@
+/**
+ * Setup modal.
+ *
+ * A polished modal presenting two paths for getting started with
+ * Claudaborative Editing: the hosted cloud service or local CLI setup.
+ * Triggered from the AiActionsMenu when the MCP server is disconnected.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, Button, ExternalLink, Icon } from '@wordpress/components';
+import { useState, useCallback } from '@wordpress/element';
+import { cloud, code } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import SparkleIcon from '../SparkleIcon';
+
+import './style.scss';
+
+const SETUP_COMMAND = 'npx claudaborative-editing start';
+
+interface SetupModalProps {
+	onRequestClose: () => void;
+}
+
+/**
+ * SetupModal component.
+ *
+ * Renders a modal with two setup option cards: hosted cloud service
+ * and local CLI setup via Claude Code.
+ *
+ * @param props                Component props.
+ * @param props.onRequestClose Callback to close the modal.
+ * @return Rendered modal.
+ */
+export default function SetupModal({ onRequestClose }: SetupModalProps) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = useCallback(() => {
+		navigator.clipboard.writeText(SETUP_COMMAND).then(
+			() => {
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			},
+			() => {
+				// Clipboard API unavailable (e.g., HTTP-only local dev).
+				// The <code> element has user-select: all, so users can
+				// still select and copy manually.
+			}
+		);
+	}, []);
+
+	return (
+		<Modal
+			title={__('Get Started', 'claudaborative-editing')}
+			onRequestClose={onRequestClose}
+			className="wpce-setup-modal"
+			icon={<SparkleIcon size={24} />}
+		>
+			<p className="wpce-setup-modal-intro">
+				{__(
+					'Choose how you want to connect Claudaborative Editing to your site:',
+					'claudaborative-editing'
+				)}
+			</p>
+
+			<div className="wpce-setup-modal-options">
+				<div className="wpce-setup-modal-card wpce-setup-modal-card-cloud">
+					<div className="wpce-setup-modal-card-header">
+						<Icon icon={cloud} size={24} />
+						<h3>
+							{__(
+								'Claudaborative Cloud',
+								'claudaborative-editing'
+							)}
+						</h3>
+						<span className="wpce-setup-modal-badge">
+							{__('Recommended', 'claudaborative-editing')}
+						</span>
+					</div>
+					<p>
+						{__(
+							'The fastest way to get started. Sign up for the hosted service and connect your site in minutes, no local software needed.',
+							'claudaborative-editing'
+						)}
+					</p>
+					<ul>
+						<li>
+							{__(
+								'No installation required',
+								'claudaborative-editing'
+							)}
+						</li>
+						<li>
+							{__(
+								'Works from any device',
+								'claudaborative-editing'
+							)}
+						</li>
+						<li>
+							{__('Automatic updates', 'claudaborative-editing')}
+						</li>
+					</ul>
+					<div className="wpce-setup-modal-card-action">
+						<ExternalLink href="https://claudaborative.cloud">
+							{__(
+								'Sign up at claudaborative.cloud',
+								'claudaborative-editing'
+							)}
+						</ExternalLink>
+					</div>
+				</div>
+
+				<div className="wpce-setup-modal-card wpce-setup-modal-card-local">
+					<div className="wpce-setup-modal-card-header">
+						<Icon icon={code} size={24} />
+						<h3>
+							{__('Set up locally', 'claudaborative-editing')}
+						</h3>
+					</div>
+					<p>
+						{__(
+							'Run Claudaborative Editing on your own computer using Claude Code. Best for developers who prefer full control.',
+							'claudaborative-editing'
+						)}
+					</p>
+					<ul>
+						<li>
+							{__(
+								'Runs on your machine',
+								'claudaborative-editing'
+							)}
+						</li>
+						<li>
+							{__(
+								'Full control over the connection',
+								'claudaborative-editing'
+							)}
+						</li>
+						<li>
+							{__(
+								'Requires Claude Code',
+								'claudaborative-editing'
+							)}
+						</li>
+					</ul>
+					<div className="wpce-setup-modal-card-action">
+						<div className="wpce-setup-modal-command-row">
+							<code className="wpce-setup-modal-command">
+								{SETUP_COMMAND}
+							</code>
+							<Button
+								variant="tertiary"
+								size="small"
+								className="wpce-setup-modal-copy-button"
+								onClick={handleCopy}
+							>
+								{copied
+									? __('Copied!', 'claudaborative-editing')
+									: __('Copy', 'claudaborative-editing')}
+							</Button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/wordpress-plugin/src/components/SetupModal/index.tsx
+++ b/wordpress-plugin/src/components/SetupModal/index.tsx
@@ -11,12 +11,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Modal, Button, ExternalLink, Icon } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
 import { cloud, code } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
 import SparkleIcon from '../SparkleIcon';
 
 import './style.scss';
@@ -38,21 +38,7 @@ interface SetupModalProps {
  * @return Rendered modal.
  */
 export default function SetupModal({ onRequestClose }: SetupModalProps) {
-	const [copied, setCopied] = useState(false);
-
-	const handleCopy = useCallback(() => {
-		navigator.clipboard.writeText(SETUP_COMMAND).then(
-			() => {
-				setCopied(true);
-				setTimeout(() => setCopied(false), 2000);
-			},
-			() => {
-				// Clipboard API unavailable (e.g., HTTP-only local dev).
-				// The <code> element has user-select: all, so users can
-				// still select and copy manually.
-			}
-		);
-	}, []);
+	const { copied, handleCopy } = useCopyToClipboard(SETUP_COMMAND);
 
 	return (
 		<Modal

--- a/wordpress-plugin/src/components/SetupModal/index.tsx
+++ b/wordpress-plugin/src/components/SetupModal/index.tsx
@@ -17,11 +17,10 @@ import { cloud, code } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
+import { SETUP_COMMAND } from '../../constants';
 import SparkleIcon from '../SparkleIcon';
 
 import './style.scss';
-
-const SETUP_COMMAND = 'npx claudaborative-editing start';
 
 interface SetupModalProps {
 	onRequestClose: () => void;

--- a/wordpress-plugin/src/components/SetupModal/style.scss
+++ b/wordpress-plugin/src/components/SetupModal/style.scss
@@ -9,7 +9,7 @@
 
 .wpce-setup-modal-options {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 	gap: 16px;
 }
 

--- a/wordpress-plugin/src/components/SetupModal/style.scss
+++ b/wordpress-plugin/src/components/SetupModal/style.scss
@@ -1,0 +1,107 @@
+.wpce-setup-modal {
+	max-width: 770px;
+}
+
+.wpce-setup-modal-intro {
+	color: #757575;
+	margin-bottom: 20px;
+}
+
+.wpce-setup-modal-options {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+
+.wpce-setup-modal-card {
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	padding: 20px;
+	position: relative;
+
+	p {
+		font-size: 13px;
+		color: #555;
+		line-height: 1.5;
+	}
+
+	ul {
+		list-style: none;
+		padding: 0;
+		margin: 12px 0 16px;
+	}
+
+	li {
+		font-size: 13px;
+		color: #555;
+		padding: 2px 0 2px 20px;
+		position: relative;
+
+		&::before {
+			content: "\2713";
+			position: absolute;
+			left: 0;
+			color: #1e8a3c;
+			font-weight: 600;
+		}
+	}
+}
+
+.wpce-setup-modal-card-cloud {
+	border-color: #d97706;
+	background: #fffbf0;
+}
+
+.wpce-setup-modal-card-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+
+	svg {
+		fill: #1e1e1e;
+	}
+
+	h3 {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+	}
+}
+
+.wpce-setup-modal-badge {
+	display: inline-block;
+	font-size: 11px;
+	font-weight: 600;
+	color: #92400e;
+	background: #fde68a;
+	padding: 2px 8px;
+	border-radius: 10px;
+	margin-bottom: 2px;
+	margin-left: auto;
+}
+
+.wpce-setup-modal-card-action {
+	margin-top: auto;
+}
+
+.wpce-setup-modal-command-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.wpce-setup-modal-command {
+	font-size: 12px;
+	background: #f0f0f0;
+	padding: 6px 10px;
+	border-radius: 4px;
+	user-select: all;
+	flex: 1;
+	min-width: 0;
+}
+
+.wpce-setup-modal-copy-button.components-button {
+	font-size: 12px;
+	flex-shrink: 0;
+}

--- a/wordpress-plugin/src/components/SetupModal/test/index.test.tsx
+++ b/wordpress-plugin/src/components/SetupModal/test/index.test.tsx
@@ -1,0 +1,161 @@
+jest.mock('@wordpress/i18n', () => ({
+	__: (str: string) => str,
+}));
+
+jest.mock('@wordpress/components', () => {
+	const { createElement } = require('react');
+	return {
+		Modal: ({ children, title, onRequestClose, className, icon }: any) =>
+			createElement(
+				'div',
+				{
+					'data-testid': 'modal',
+					className,
+					role: 'dialog',
+					'aria-label': title,
+				},
+				icon &&
+					createElement(
+						'span',
+						{ 'data-testid': 'modal-icon' },
+						icon
+					),
+				createElement(
+					'button',
+					{
+						'data-testid': 'modal-close',
+						onClick: onRequestClose,
+					},
+					'Close'
+				),
+				children
+			),
+		Button: ({
+			children,
+			onClick,
+			className,
+			variant: _v,
+			size: _s,
+			...props
+		}: any) =>
+			createElement('button', { onClick, className, ...props }, children),
+		ExternalLink: ({ children, href, ...props }: any) =>
+			createElement('a', { href, target: '_blank', ...props }, children),
+		Icon: ({ icon, size }: any) =>
+			createElement('span', {
+				'data-testid': 'icon',
+				'data-icon': icon?.name ?? 'unknown',
+				'data-size': size,
+			}),
+	};
+});
+
+jest.mock('@wordpress/icons', () => ({
+	cloud: { name: 'cloud' },
+	code: { name: 'code' },
+}));
+
+jest.mock('../../SparkleIcon', () => {
+	const { createElement } = require('react');
+	return {
+		__esModule: true,
+		default: ({ size }: { size?: number }) =>
+			createElement('span', {
+				'data-testid': 'sparkle-icon',
+				'data-size': size,
+			}),
+	};
+});
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import SetupModal from '..';
+
+describe('SetupModal', () => {
+	let clipboardSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		clipboardSpy = jest.fn().mockResolvedValue(undefined);
+		Object.assign(navigator, {
+			clipboard: { writeText: clipboardSpy },
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('renders modal with title', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		const modal = screen.getByTestId('modal');
+		expect(modal.getAttribute('aria-label')).toBe('Get Started');
+	});
+
+	it('renders SparkleIcon in modal header', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		expect(screen.getByTestId('sparkle-icon')).toBeTruthy();
+	});
+
+	it('renders cloud option with link to claudaborative.cloud', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		expect(screen.getByText('Claudaborative Cloud')).toBeTruthy();
+		expect(screen.getByText('Recommended')).toBeTruthy();
+
+		const link = screen.getByText('Sign up at claudaborative.cloud');
+		expect(link.tagName).toBe('A');
+		expect(link.getAttribute('href')).toBe('https://claudaborative.cloud');
+	});
+
+	it('renders cloud option benefits', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		expect(screen.getByText('No installation required')).toBeTruthy();
+		expect(screen.getByText('Works from any device')).toBeTruthy();
+		expect(screen.getByText('Automatic updates')).toBeTruthy();
+	});
+
+	it('renders local setup option with command', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		expect(screen.getByText('Set up locally')).toBeTruthy();
+		expect(
+			screen.getByText('npx claudaborative-editing start')
+		).toBeTruthy();
+	});
+
+	it('renders local setup benefits', () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+		expect(screen.getByText('Runs on your machine')).toBeTruthy();
+		expect(
+			screen.getByText('Full control over the connection')
+		).toBeTruthy();
+		expect(screen.getByText('Requires Claude Code')).toBeTruthy();
+	});
+
+	it('copy button copies command to clipboard', async () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+
+		await act(async () => fireEvent.click(screen.getByText('Copy')));
+
+		expect(clipboardSpy).toHaveBeenCalledWith(
+			'npx claudaborative-editing start'
+		);
+	});
+
+	it('copy button shows "Copied!" feedback', async () => {
+		render(<SetupModal onRequestClose={jest.fn()} />);
+
+		await act(async () => fireEvent.click(screen.getByText('Copy')));
+
+		expect(screen.getByText('Copied!')).toBeTruthy();
+
+		act(() => jest.advanceTimersByTime(2000));
+		expect(screen.getByText('Copy')).toBeTruthy();
+	});
+
+	it('calls onRequestClose when modal close is clicked', () => {
+		const onClose = jest.fn();
+		render(<SetupModal onRequestClose={onClose} />);
+
+		fireEvent.click(screen.getByTestId('modal-close'));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/wordpress-plugin/src/components/SetupModal/test/index.test.tsx
+++ b/wordpress-plugin/src/components/SetupModal/test/index.test.tsx
@@ -1,3 +1,11 @@
+const mockHandleCopy = jest.fn();
+jest.mock('../../../hooks/use-copy-to-clipboard', () => ({
+	useCopyToClipboard: jest.fn(() => ({
+		copied: false,
+		handleCopy: mockHandleCopy,
+	})),
+}));
+
 jest.mock('@wordpress/i18n', () => ({
 	__: (str: string) => str,
 }));
@@ -67,22 +75,19 @@ jest.mock('../../SparkleIcon', () => {
 	};
 });
 
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useCopyToClipboard } from '../../../hooks/use-copy-to-clipboard';
 import SetupModal from '..';
 
+const mockedUseCopyToClipboard = useCopyToClipboard as jest.Mock;
+
 describe('SetupModal', () => {
-	let clipboardSpy: jest.SpyInstance;
-
 	beforeEach(() => {
-		jest.useFakeTimers();
-		clipboardSpy = jest.fn().mockResolvedValue(undefined);
-		Object.assign(navigator, {
-			clipboard: { writeText: clipboardSpy },
+		jest.clearAllMocks();
+		mockedUseCopyToClipboard.mockReturnValue({
+			copied: false,
+			handleCopy: mockHandleCopy,
 		});
-	});
-
-	afterEach(() => {
-		jest.useRealTimers();
 	});
 
 	it('renders modal with title', () => {
@@ -130,25 +135,23 @@ describe('SetupModal', () => {
 		expect(screen.getByText('Requires Claude Code')).toBeTruthy();
 	});
 
-	it('copy button copies command to clipboard', async () => {
+	it('copy button calls handleCopy from useCopyToClipboard', () => {
 		render(<SetupModal onRequestClose={jest.fn()} />);
 
-		await act(async () => fireEvent.click(screen.getByText('Copy')));
+		fireEvent.click(screen.getByText('Copy'));
 
-		expect(clipboardSpy).toHaveBeenCalledWith(
-			'npx claudaborative-editing start'
-		);
+		expect(mockHandleCopy).toHaveBeenCalled();
 	});
 
-	it('copy button shows "Copied!" feedback', async () => {
+	it('copy button shows "Copied!" feedback when copied is true', () => {
+		mockedUseCopyToClipboard.mockReturnValue({
+			copied: true,
+			handleCopy: mockHandleCopy,
+		});
+
 		render(<SetupModal onRequestClose={jest.fn()} />);
 
-		await act(async () => fireEvent.click(screen.getByText('Copy')));
-
 		expect(screen.getByText('Copied!')).toBeTruthy();
-
-		act(() => jest.advanceTimersByTime(2000));
-		expect(screen.getByText('Copy')).toBeTruthy();
 	});
 
 	it('calls onRequestClose when modal close is clicked', () => {

--- a/wordpress-plugin/src/constants.ts
+++ b/wordpress-plugin/src/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The CLI command shown in onboarding UI for local setup.
+ */
+export const SETUP_COMMAND = 'npx claudaborative-editing start';

--- a/wordpress-plugin/src/hooks/test/use-copy-to-clipboard.test.ts
+++ b/wordpress-plugin/src/hooks/test/use-copy-to-clipboard.test.ts
@@ -90,6 +90,42 @@ describe('useCopyToClipboard', () => {
 		expect(result.current.copied).toBe(false);
 	});
 
+	it('clears previous timeout when copy is triggered again quickly', async () => {
+		const { result } = renderHook(() => useCopyToClipboard('test'));
+
+		// First copy
+		await act(async () => {
+			result.current.handleCopy();
+		});
+		expect(result.current.copied).toBe(true);
+
+		// Advance partway through the 2s timeout
+		act(() => {
+			jest.advanceTimersByTime(1000);
+		});
+		expect(result.current.copied).toBe(true);
+
+		// Second copy — should clear the first timeout and start a fresh 2s
+		await act(async () => {
+			result.current.handleCopy();
+		});
+		expect(result.current.copied).toBe(true);
+
+		// Advance another 1s (total 2s from first copy, but only 1s from second)
+		act(() => {
+			jest.advanceTimersByTime(1000);
+		});
+
+		// Should still be true — the first timeout was cleared, second has 1s left
+		expect(result.current.copied).toBe(true);
+
+		// Advance the remaining 1s for the second timeout
+		act(() => {
+			jest.advanceTimersByTime(1000);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
 	it('cleans up timeout on unmount', async () => {
 		const { result, unmount } = renderHook(() =>
 			useCopyToClipboard('test')

--- a/wordpress-plugin/src/hooks/test/use-copy-to-clipboard.test.ts
+++ b/wordpress-plugin/src/hooks/test/use-copy-to-clipboard.test.ts
@@ -1,0 +1,112 @@
+jest.mock('@wordpress/element', () => {
+	const React = require('react');
+	return {
+		useState: React.useState,
+		useCallback: React.useCallback,
+		useRef: React.useRef,
+		useEffect: React.useEffect,
+	};
+});
+
+import { renderHook, act } from '@testing-library/react';
+import { useCopyToClipboard } from '../use-copy-to-clipboard';
+
+describe('useCopyToClipboard', () => {
+	let clipboardSpy: jest.Mock;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		clipboardSpy = jest.fn().mockResolvedValue(undefined);
+		Object.assign(navigator, {
+			clipboard: { writeText: clipboardSpy },
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('calls navigator.clipboard.writeText with the provided text', async () => {
+		const { result } = renderHook(() =>
+			useCopyToClipboard('npx claudaborative-editing start')
+		);
+
+		await act(async () => {
+			result.current.handleCopy();
+		});
+
+		expect(clipboardSpy).toHaveBeenCalledWith(
+			'npx claudaborative-editing start'
+		);
+	});
+
+	it('sets copied to true after successful write and resets after 2000ms', async () => {
+		const { result } = renderHook(() => useCopyToClipboard('hello'));
+
+		expect(result.current.copied).toBe(false);
+
+		await act(async () => {
+			result.current.handleCopy();
+		});
+
+		expect(result.current.copied).toBe(true);
+
+		act(() => {
+			jest.advanceTimersByTime(2000);
+		});
+
+		expect(result.current.copied).toBe(false);
+	});
+
+	it('does not throw when navigator.clipboard is undefined', () => {
+		Object.defineProperty(navigator, 'clipboard', {
+			value: undefined,
+			writable: true,
+			configurable: true,
+		});
+
+		const { result } = renderHook(() => useCopyToClipboard('test'));
+
+		expect(() => result.current.handleCopy()).not.toThrow();
+	});
+
+	it('does not throw when navigator.clipboard.writeText is undefined', () => {
+		Object.assign(navigator, { clipboard: {} });
+
+		const { result } = renderHook(() => useCopyToClipboard('test'));
+
+		expect(() => result.current.handleCopy()).not.toThrow();
+	});
+
+	it('handles rejected clipboard write gracefully', async () => {
+		clipboardSpy.mockRejectedValueOnce(new Error('Permission denied'));
+
+		const { result } = renderHook(() => useCopyToClipboard('test'));
+
+		await act(async () => {
+			result.current.handleCopy();
+		});
+
+		expect(result.current.copied).toBe(false);
+	});
+
+	it('cleans up timeout on unmount', async () => {
+		const { result, unmount } = renderHook(() =>
+			useCopyToClipboard('test')
+		);
+
+		await act(async () => {
+			result.current.handleCopy();
+		});
+
+		expect(result.current.copied).toBe(true);
+
+		// Unmount while copied is still true
+		unmount();
+
+		// Advance timers past the timeout — should not throw
+		act(() => {
+			jest.advanceTimersByTime(3000);
+		});
+	});
+});

--- a/wordpress-plugin/src/hooks/use-copy-to-clipboard.ts
+++ b/wordpress-plugin/src/hooks/use-copy-to-clipboard.ts
@@ -5,7 +5,9 @@ export function useCopyToClipboard(text: string): {
 	handleCopy: () => void;
 } {
 	const [copied, setCopied] = useState(false);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined
+	);
 
 	useEffect(() => {
 		return () => {
@@ -22,7 +24,13 @@ export function useCopyToClipboard(text: string): {
 		navigator.clipboard.writeText(text).then(
 			() => {
 				setCopied(true);
-				timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+				if (timeoutRef.current) {
+					clearTimeout(timeoutRef.current);
+				}
+				timeoutRef.current = setTimeout(() => {
+					setCopied(false);
+					timeoutRef.current = undefined;
+				}, 2000);
 			},
 			() => {
 				// Clipboard write rejected (e.g., permission denied).

--- a/wordpress-plugin/src/hooks/use-copy-to-clipboard.ts
+++ b/wordpress-plugin/src/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+
+export function useCopyToClipboard(text: string): {
+	copied: boolean;
+	handleCopy: () => void;
+} {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, []);
+
+	const handleCopy = useCallback(() => {
+		if (!navigator.clipboard?.writeText) {
+			return;
+		}
+		navigator.clipboard.writeText(text).then(
+			() => {
+				setCopied(true);
+				timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+			},
+			() => {
+				// Clipboard write rejected (e.g., permission denied).
+				// The <code> element has user-select: all for manual copy.
+			}
+		);
+	}, [text]);
+
+	return { copied, handleCopy };
+}


### PR DESCRIPTION
## Summary

- When the MCP server is disconnected, the plugin now shows actionable setup guidance instead of just "Status: disconnected"
- Two setup paths are presented throughout: **Claudaborative Cloud** (hosted, recommended) and **local CLI** via Claude Code
- The CLI setup wizard's completion message now includes explicit next steps

### Plugin changes

- **ConnectionStatus popover**: Shows onboarding content with highlighted cloud option and copyable CLI command. Distinguishes first-time setup (shows onboarding) from temporary disconnections (shows "Reconnecting...")
- **AiActionsMenu**: "Not connected" notice with red status dot and "Get started" button that opens a polished SetupModal
- **SetupModal** (new): Two-column card layout with benefit lists, "Recommended" badge on cloud option, and copy-to-clipboard command for local setup

### CLI changes

- Setup completion message replaced with multi-step next instructions including claudaborative.cloud mention

Closes #79

## Test plan

- [ ] Activate plugin with no MCP server running — footer sparkle popover shows onboarding with cloud highlight and local CLI option
- [ ] Click "Get started" in toolbar sparkle dropdown — SetupModal opens with two cards
- [ ] Cloud link opens claudaborative.cloud in new tab
- [ ] Copy button copies `npx claudaborative-editing start` to clipboard
- [ ] Connect MCP server, then disconnect — popover shows "Reconnecting..." instead of onboarding
- [ ] Run `npx claudaborative-editing setup` — completion message shows next steps with claudaborative.cloud mention
- [ ] All existing AI action commands still work when connected