### PR TITLE
fix: discover REST API URL from site instead of hardcoding /wp-json

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -352,11 +352,27 @@ async function validateCredentials(
 	deps.log('');
 	deps.log('Validating credentials...');
 
+	// Discover REST API URL from the site
+	const discovery = await WordPressApiClient.discover(credentials.siteUrl);
+
 	const client = new WordPressApiClient({
 		siteUrl: credentials.siteUrl,
 		username: credentials.username,
 		appPassword: credentials.appPassword,
+		restUrl: discovery.restUrl,
 	});
+
+	// Check application-passwords support before attempting auth
+	try {
+		await client.checkAuthSupport();
+	} catch (err) {
+		if (err instanceof WordPressApiError) {
+			deps.error(err.message);
+		} else {
+			deps.error('Could not check authentication support.');
+		}
+		deps.exit(1);
+	}
 
 	try {
 		const user = await client.validateConnection();
@@ -373,9 +389,6 @@ async function validateCredentials(
 		deps.exit(1);
 	}
 
-	const wpVersion = await client.getWordPressVersion();
-	deps.log(`  WordPress version: ${wpVersion}`);
-
 	try {
 		await client.validateSyncEndpoint();
 		deps.log('  ✓ Collaborative editing endpoint available');
@@ -385,9 +398,6 @@ async function validateCredentials(
 			deps.error(
 				'Collaborative editing is not available.\n' +
 					'  Requires WordPress 7.0 or later, or the Gutenberg plugin 22.8 or later.\n' +
-					(wpVersion !== 'unknown'
-						? `  Current WordPress version: ${wpVersion}\n`
-						: '') +
 					'  If using WordPress 7.0+, enable collaborative editing in Settings → Writing.'
 			);
 			deps.exit(1);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -366,11 +366,7 @@ async function validateCredentials(
 	try {
 		await client.checkAuthSupport();
 	} catch (err) {
-		if (err instanceof WordPressApiError) {
-			deps.error(err.message);
-		} else {
-			deps.error('Could not check authentication support.');
-		}
+		deps.error(err instanceof Error ? err.message : String(err));
 		deps.exit(1);
 	}
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -429,12 +429,14 @@ export class SessionManager {
 			await this.disconnect();
 		}
 
-		// Discover REST API URL from the site
-		const discovery = await WordPressApiClient.discover(config.siteUrl);
+		// Discover REST API URL from the site only when the caller did not provide one
+		const restUrl =
+			config.restUrl ??
+			(await WordPressApiClient.discover(config.siteUrl)).restUrl;
 
 		this._apiClient = new WordPressApiClient({
 			...config,
-			restUrl: config.restUrl ?? discovery.restUrl,
+			restUrl,
 		});
 
 		// Check application-passwords support before first authenticated request

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -429,7 +429,16 @@ export class SessionManager {
 			await this.disconnect();
 		}
 
-		this._apiClient = new WordPressApiClient(config);
+		// Discover REST API URL from the site
+		const discovery = await WordPressApiClient.discover(config.siteUrl);
+
+		this._apiClient = new WordPressApiClient({
+			...config,
+			restUrl: config.restUrl ?? discovery.restUrl,
+		});
+
+		// Check application-passwords support before first authenticated request
+		await this.apiClient.checkAuthSupport();
 
 		// Validate credentials
 		const user = await this.apiClient.validateConnection();

--- a/src/wordpress/api-client.ts
+++ b/src/wordpress/api-client.ts
@@ -10,6 +10,11 @@ import type {
 	SyncResponse,
 } from './types.js';
 
+/** Result of REST API URL discovery from the site's home page. */
+export interface DiscoveryResult {
+	restUrl: string;
+}
+
 /**
  * WordPress REST API client using Application Password (HTTP Basic Auth).
  *
@@ -18,13 +23,84 @@ import type {
 export class WordPressApiClient {
 	private siteUrl: string;
 	private baseUrl: string;
+	private restRouteMode: boolean;
 	private authHeader: string;
 
 	constructor(config: WordPressConfig) {
 		// Normalise URL: strip trailing slash(es)
 		this.siteUrl = config.siteUrl.replace(/\/+$/, '');
-		this.baseUrl = `${this.siteUrl}/wp-json`;
+		const restUrl = config.restUrl ?? `${this.siteUrl}/wp-json`;
+
+		// Detect ?rest_route= style (non-pretty permalinks)
+		const match = restUrl.match(/^(.+?)\?rest_route=\/?$/);
+		if (match) {
+			this.baseUrl = match[1].replace(/\/+$/, '');
+			this.restRouteMode = true;
+		} else {
+			this.baseUrl = restUrl.replace(/\/+$/, '');
+			this.restRouteMode = false;
+		}
+
 		this.authHeader = `Basic ${btoa(config.username + ':' + config.appPassword)}`;
+	}
+
+	/**
+	 * Discover the REST API URL for a WordPress site.
+	 *
+	 * Fetches the site's home page (unauthenticated) and extracts the REST API
+	 * URL from the HTTP `Link` header or HTML `<link>` tag. Falls back to
+	 * `${siteUrl}/wp-json` if discovery fails.
+	 */
+	static async discover(siteUrl: string): Promise<DiscoveryResult> {
+		const normalised = siteUrl.replace(/\/+$/, '');
+		const fallback: DiscoveryResult = {
+			restUrl: `${normalised}/wp-json`,
+		};
+
+		let response: Response;
+		try {
+			response = await fetch(normalised, {
+				signal: AbortSignal.timeout(10_000),
+				headers: { Accept: 'text/html' },
+			});
+		} catch {
+			return fallback;
+		}
+
+		if (!response.ok) {
+			return fallback;
+		}
+
+		// 1. Check the HTTP Link header (most reliable — works regardless of content type)
+		const linkHeader = response.headers.get('Link') ?? '';
+		const linkMatch = linkHeader.match(
+			/<([^>]+)>;\s*rel="https:\/\/api\.w\.org\/"/
+		);
+		if (linkMatch) {
+			return { restUrl: linkMatch[1] };
+		}
+
+		// 2. Fallback: parse HTML <link> tag
+		let body: string;
+		try {
+			body = await response.text();
+		} catch {
+			return fallback;
+		}
+
+		// Handle both attribute orders: rel before href, and href before rel
+		const htmlMatch =
+			body.match(
+				/<link\s[^>]*rel=["']https:\/\/api\.w\.org\/["'][^>]*href=["']([^"']+)["']/i
+			) ??
+			body.match(
+				/<link\s[^>]*href=["']([^"']+)["'][^>]*rel=["']https:\/\/api\.w\.org\/["']/i
+			);
+		if (htmlMatch) {
+			return { restUrl: htmlMatch[1] };
+		}
+
+		return fallback;
 	}
 
 	/**
@@ -52,26 +128,40 @@ export class WordPressApiClient {
 	}
 
 	/**
-	 * Fetch the WordPress version from the REST API root.
+	 * Check whether the site supports Application Password authentication.
 	 *
-	 * Returns the version string, or `'unknown'` if it could not be
-	 * determined (e.g. the endpoint is unavailable or the field is missing).
-	 * Never throws — callers decide how to act on the result.
+	 * Fetches the REST API root (unauthenticated) and inspects the
+	 * `authentication` object. Only throws if it can positively confirm that
+	 * application-passwords are NOT listed among other auth methods. If the
+	 * field is missing, empty, or the request fails, it does nothing.
 	 */
-	async getWordPressVersion(): Promise<string> {
-		let data: { version?: string };
+	async checkAuthSupport(): Promise<void> {
+		let data: { authentication?: Record<string, unknown> };
 		try {
-			data = await this.apiFetch<{ version?: string }>('/');
+			const url = this.buildApiUrl('/');
+			const response = await fetch(url, {
+				headers: { Accept: 'application/json' },
+			});
+			if (!response.ok) return;
+			data = (await response.json()) as typeof data;
 		} catch {
-			return 'unknown';
+			return;
 		}
 
-		const version = data.version;
-		if (typeof version !== 'string' || version.trim() === '') {
-			return 'unknown';
+		const auth = data.authentication;
+		if (
+			auth &&
+			typeof auth === 'object' &&
+			Object.keys(auth).length > 0 &&
+			!('application-passwords' in auth)
+		) {
+			throw new WordPressApiError(
+				'This WordPress site does not support Application Passwords. ' +
+					'Application Passwords require WordPress 5.6+ and must not be disabled by a security plugin.',
+				0,
+				''
+			);
 		}
-
-		return version;
 	}
 
 	/**
@@ -392,10 +482,27 @@ export class WordPressApiClient {
 	}
 
 	/**
+	 * Build a full API URL from a path, handling both pretty-permalink
+	 * (`/wp-json/path`) and non-pretty-permalink (`?rest_route=/path`) styles.
+	 */
+	private buildApiUrl(path: string): string {
+		if (this.restRouteMode) {
+			const qIndex = path.indexOf('?');
+			if (qIndex === -1) {
+				return `${this.baseUrl}?rest_route=${path}`;
+			}
+			const pathPart = path.substring(0, qIndex);
+			const queryPart = path.substring(qIndex + 1);
+			return `${this.baseUrl}?rest_route=${pathPart}&${queryPart}`;
+		}
+		return `${this.baseUrl}${path}`;
+	}
+
+	/**
 	 * Internal fetch helper with auth and error handling.
 	 */
 	private async apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-		const url = `${this.baseUrl}${path}`;
+		const url = this.buildApiUrl(path);
 
 		const headers: Record<string, string> = {
 			Authorization: this.authHeader,

--- a/src/wordpress/types.ts
+++ b/src/wordpress/types.ts
@@ -164,6 +164,8 @@ export interface WordPressConfig {
 	siteUrl: string;
 	username: string;
 	appPassword: string;
+	/** REST API base URL discovered from the site (e.g., https://example.com/wp-json). */
+	restUrl?: string;
 }
 
 // --- Sync Client Config ---

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -264,6 +264,23 @@ describe('WordPressApiClient', () => {
 			});
 		});
 
+		it('falls back to /wp-json when response.text() throws', async () => {
+			const headers = new Headers();
+			fetchMock.mockResolvedValue({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+				headers,
+				text: () => Promise.reject(new Error('body stream error')),
+			} as unknown as Response);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json',
+			});
+		});
+
 		it('strips trailing slashes from siteUrl', async () => {
 			fetchMock.mockRejectedValue(new TypeError('fetch failed'));
 			const result = await WordPressApiClient.discover(

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -100,6 +100,294 @@ describe('WordPressApiClient', () => {
 				(callOptions.headers as Record<string, string>).Authorization
 			).toBe(expectedAuth);
 		});
+
+		it('uses restUrl for API calls when provided', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/blog/wp-json',
+			});
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com/blog/wp-json/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+
+		it('enters restRouteMode when restUrl contains ?rest_route=', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/?rest_route=/',
+			});
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com?rest_route=/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+
+		it('strips trailing slashes from restUrl', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/blog/wp-json/',
+			});
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com/blog/wp-json/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+	});
+
+	describe('discover', () => {
+		function mockDiscoverResponse(options: {
+			ok?: boolean;
+			status?: number;
+			linkHeader?: string | null;
+			body?: string;
+		}): Response {
+			const ok = options.ok ?? true;
+			const status = options.status ?? 200;
+			const headers = new Headers();
+			if (options.linkHeader) {
+				headers.set('Link', options.linkHeader);
+			}
+			return {
+				ok,
+				status,
+				statusText: ok ? 'OK' : 'Error',
+				headers,
+				text: () => Promise.resolve(options.body ?? ''),
+				json: () => Promise.resolve({}),
+			} as unknown as Response;
+		}
+
+		it('extracts REST URL from Link header', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({
+					linkHeader:
+						'<https://example.com/wp-json/>; rel="https://api.w.org/"',
+				})
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json/',
+			});
+		});
+
+		it('falls back to HTML link tag when no Link header', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({
+					body: '<html><head><link rel="https://api.w.org/" href="https://example.com/wp-json/" /></head></html>',
+				})
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json/',
+			});
+		});
+
+		it('handles href-before-rel attribute order in HTML link tag', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({
+					body: '<html><head><link href="https://example.com/wp-json/" rel="https://api.w.org/" /></head></html>',
+				})
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json/',
+			});
+		});
+
+		it('handles ?rest_route= in Link header', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({
+					linkHeader:
+						'<https://example.com/?rest_route=/>; rel="https://api.w.org/"',
+				})
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/?rest_route=/',
+			});
+		});
+
+		it('falls back to /wp-json when no discovery info found', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({
+					body: '<html><head><title>My Site</title></head></html>',
+				})
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json',
+			});
+		});
+
+		it('falls back to /wp-json on network error', async () => {
+			fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json',
+			});
+		});
+
+		it('falls back to /wp-json on non-OK response', async () => {
+			fetchMock.mockResolvedValue(
+				mockDiscoverResponse({ ok: false, status: 403 })
+			);
+			const result = await WordPressApiClient.discover(
+				'https://example.com'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json',
+			});
+		});
+
+		it('strips trailing slashes from siteUrl', async () => {
+			fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+			const result = await WordPressApiClient.discover(
+				'https://example.com/'
+			);
+			expect(result).toEqual({
+				restUrl: 'https://example.com/wp-json',
+			});
+		});
+	});
+
+	describe('checkAuthSupport', () => {
+		it('does not throw when application-passwords is present', async () => {
+			fetchMock.mockResolvedValue(
+				mockResponse({
+					authentication: {
+						'application-passwords': { endpoints: {} },
+					},
+				})
+			);
+			const client = createClient();
+			await expect(client.checkAuthSupport()).resolves.toBeUndefined();
+		});
+
+		it('throws when auth methods exist but no application-passwords', async () => {
+			fetchMock.mockResolvedValue(
+				mockResponse({
+					authentication: { cookie: {} },
+				})
+			);
+			const client = createClient();
+			await expect(client.checkAuthSupport()).rejects.toThrow(
+				WordPressApiError
+			);
+			await expect(client.checkAuthSupport()).rejects.toThrow(
+				/Application Passwords/
+			);
+		});
+
+		it('does not throw when authentication field is empty', async () => {
+			fetchMock.mockResolvedValue(mockResponse({ authentication: {} }));
+			const client = createClient();
+			await expect(client.checkAuthSupport()).resolves.toBeUndefined();
+		});
+
+		it('does not throw when authentication field is missing', async () => {
+			fetchMock.mockResolvedValue(mockResponse({}));
+			const client = createClient();
+			await expect(client.checkAuthSupport()).resolves.toBeUndefined();
+		});
+
+		it('does not throw on fetch error', async () => {
+			fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+			const client = createClient();
+			await expect(client.checkAuthSupport()).resolves.toBeUndefined();
+		});
+
+		it('does not throw on non-OK response', async () => {
+			fetchMock.mockResolvedValue(
+				mockResponse(
+					{ code: 'internal_error', message: 'Server Error' },
+					{ status: 500, statusText: 'Internal Server Error' }
+				)
+			);
+			const client = createClient();
+			await expect(client.checkAuthSupport()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('URL construction', () => {
+		it('uses default /wp-json base URL', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = createClient();
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com/wp-json/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+
+		it('uses custom restUrl for API calls', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/blog/wp-json',
+			});
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com/blog/wp-json/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+
+		it('builds restRouteMode URL for simple path', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakeUser));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/?rest_route=/',
+			});
+			void client.getCurrentUser();
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com?rest_route=/wp/v2/users/me',
+				expect.anything()
+			);
+		});
+
+		it('builds restRouteMode URL for path with query params', () => {
+			fetchMock.mockResolvedValue(mockResponse(fakePost));
+			const client = new WordPressApiClient({
+				siteUrl: 'https://example.com',
+				username: 'admin',
+				appPassword: 'xxxx yyyy zzzz',
+				restUrl: 'https://example.com/?rest_route=/',
+			});
+			void client.getPost(42);
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://example.com?rest_route=/wp/v2/posts/42&context=edit',
+				expect.anything()
+			);
+		});
 	});
 
 	describe('createUrl', () => {
@@ -153,32 +441,6 @@ describe('WordPressApiClient', () => {
 					body: JSON.stringify({ rooms: [] }),
 				})
 			);
-		});
-	});
-
-	describe('getWordPressVersion', () => {
-		it('returns version string', async () => {
-			fetchMock.mockResolvedValue(mockResponse({ version: '7.0' }));
-			const client = createClient();
-			expect(await client.getWordPressVersion()).toBe('7.0');
-		});
-
-		it('returns unknown when endpoint is unavailable', async () => {
-			fetchMock.mockRejectedValue(new Error('fetch failed'));
-			const client = createClient();
-			expect(await client.getWordPressVersion()).toBe('unknown');
-		});
-
-		it('returns unknown when version field is missing', async () => {
-			fetchMock.mockResolvedValue(mockResponse({}));
-			const client = createClient();
-			expect(await client.getWordPressVersion()).toBe('unknown');
-		});
-
-		it('returns unknown when version field is empty', async () => {
-			fetchMock.mockResolvedValue(mockResponse({ version: '' }));
-			const client = createClient();
-			expect(await client.getWordPressVersion()).toBe('unknown');
 		});
 	});
 

--- a/tests/unit/cli/setup.test.ts
+++ b/tests/unit/cli/setup.test.ts
@@ -104,9 +104,40 @@ function createTestDeps(
 	};
 }
 
-// Successful fetch responses for validation (user + version check + sync endpoint)
+// Mock response for REST API URL discovery (GET site URL with Link header)
+function mockDiscoveryResponse(
+	restUrl = 'https://example.com/wp-json/'
+): Response {
+	return {
+		ok: true,
+		status: 200,
+		headers: new Headers({
+			Link: `<${restUrl}>; rel="https://api.w.org/"`,
+		}),
+		text: () => Promise.resolve(''),
+	} as unknown as Response;
+}
+
+// Mock response for auth support check (GET REST root, unauthenticated)
+function mockAuthSupportResponse(): Response {
+	return {
+		ok: true,
+		status: 200,
+		headers: new Headers(),
+		json: () =>
+			Promise.resolve({
+				authentication: {
+					'application-passwords': { endpoints: {} },
+				},
+			}),
+	} as unknown as Response;
+}
+
+// Successful fetch responses for validation (discovery + auth check + user + sync endpoint)
 function mockSuccessfulValidation(): void {
 	fetchMock
+		.mockResolvedValueOnce(mockDiscoveryResponse())
+		.mockResolvedValueOnce(mockAuthSupportResponse())
 		.mockResolvedValueOnce(
 			mockResponse({
 				id: 1,
@@ -115,7 +146,6 @@ function mockSuccessfulValidation(): void {
 				avatar_urls: {},
 			})
 		)
-		.mockResolvedValueOnce(mockResponse({ version: '7.0' }))
 		.mockResolvedValueOnce(mockResponse({ rooms: [] }));
 }
 
@@ -196,7 +226,20 @@ describe('setup wizard', () => {
 		});
 
 		it('prepends https:// to bare domain URLs', async () => {
-			mockSuccessfulValidation();
+			fetchMock
+				.mockResolvedValueOnce(
+					mockDiscoveryResponse('https://pento.net/wp-json/')
+				)
+				.mockResolvedValueOnce(mockAuthSupportResponse())
+				.mockResolvedValueOnce(
+					mockResponse({
+						id: 1,
+						name: 'admin',
+						slug: 'admin',
+						avatar_urls: {},
+					})
+				)
+				.mockResolvedValueOnce(mockResponse({ rooms: [] }));
 			const writeConfig = vi.fn().mockResolvedValue(true);
 
 			const { deps } = createTestDeps(
@@ -210,14 +253,25 @@ describe('setup wizard', () => {
 
 			await runSetup(deps, { manual: true });
 
-			expect(fetchMock).toHaveBeenCalledWith(
-				expect.stringContaining('https://pento.net/wp-json/'),
-				expect.anything()
-			);
+			// Discovery call should use the normalised URL with https://
+			expect(fetchMock.mock.calls[0][0]).toBe('https://pento.net');
 		});
 
 		it('preserves explicit http:// scheme', async () => {
-			mockSuccessfulValidation();
+			fetchMock
+				.mockResolvedValueOnce(
+					mockDiscoveryResponse('http://localhost:8080/wp-json/')
+				)
+				.mockResolvedValueOnce(mockAuthSupportResponse())
+				.mockResolvedValueOnce(
+					mockResponse({
+						id: 1,
+						name: 'admin',
+						slug: 'admin',
+						avatar_urls: {},
+					})
+				)
+				.mockResolvedValueOnce(mockResponse({ rooms: [] }));
 			const writeConfig = vi.fn().mockResolvedValue(true);
 
 			const { deps } = createTestDeps(
@@ -231,10 +285,8 @@ describe('setup wizard', () => {
 
 			await runSetup(deps, { manual: true });
 
-			expect(fetchMock).toHaveBeenCalledWith(
-				expect.stringContaining('http://localhost:8080/wp-json/'),
-				expect.anything()
-			);
+			// Discovery call should preserve the http:// scheme
+			expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8080');
 		});
 
 		it('strips trailing slashes from URLs', async () => {
@@ -252,20 +304,20 @@ describe('setup wizard', () => {
 
 			await runSetup(deps, { manual: true });
 
-			// Should use the URL without trailing slash
-			expect(fetchMock).toHaveBeenCalledWith(
-				expect.stringContaining('https://example.com/wp-json/'),
-				expect.anything()
-			);
+			// Discovery call should strip the trailing slash
+			expect(fetchMock.mock.calls[0][0]).toBe('https://example.com');
 		});
 
 		it('exits with error on auth failure', async () => {
-			fetchMock.mockResolvedValueOnce(
-				mockResponse(
-					{ code: 'rest_forbidden', message: 'Sorry' },
-					{ status: 401, statusText: 'Unauthorized' }
-				)
-			);
+			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
+				.mockResolvedValueOnce(
+					mockResponse(
+						{ code: 'rest_forbidden', message: 'Sorry' },
+						{ status: 401, statusText: 'Unauthorized' }
+					)
+				);
 
 			const { deps, errors } = createTestDeps(
 				['https://example.com', 'admin', 'bad-password'],
@@ -281,8 +333,41 @@ describe('setup wizard', () => {
 			expect(errors.join('\n')).toContain('Authentication failed');
 		});
 
-		it('includes version in error when old WP lacks sync endpoint', async () => {
+		it('exits with error when Application Passwords are not supported', async () => {
 			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce({
+					ok: true,
+					status: 200,
+					headers: new Headers(),
+					json: () =>
+						Promise.resolve({
+							authentication: {
+								cookie: { endpoints: {} },
+							},
+						}),
+				} as unknown as Response);
+
+			const { deps, errors } = createTestDeps(
+				['https://example.com', 'admin', 'xxxx xxxx xxxx'],
+				{
+					detectClients: () => defaultClientList(),
+					hasConfig: () => false,
+				}
+			);
+
+			await expect(runSetup(deps, { manual: true })).rejects.toThrow(
+				SetupExitError
+			);
+			expect(errors.join('\n')).toContain(
+				'does not support Application Passwords'
+			);
+		});
+
+		it('shows requirements guidance when sync endpoint returns 404', async () => {
+			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
 				.mockResolvedValueOnce(
 					mockResponse({
 						id: 1,
@@ -291,7 +376,6 @@ describe('setup wizard', () => {
 						avatar_urls: {},
 					})
 				)
-				.mockResolvedValueOnce(mockResponse({ version: '6.7' }))
 				.mockResolvedValueOnce(
 					mockResponse(
 						{ code: 'rest_no_route', message: 'No route' },
@@ -314,11 +398,13 @@ describe('setup wizard', () => {
 			expect(errorText).toContain(
 				'Collaborative editing is not available'
 			);
-			expect(errorText).toContain('6.7');
+			expect(errorText).toContain('Requires WordPress 7.0 or later');
 		});
 
 		it('exits with error when sync endpoint returns 404', async () => {
 			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
 				.mockResolvedValueOnce(
 					mockResponse({
 						id: 1,
@@ -327,7 +413,6 @@ describe('setup wizard', () => {
 						avatar_urls: {},
 					})
 				)
-				.mockResolvedValueOnce(mockResponse({ version: '7.0' }))
 				.mockResolvedValueOnce(
 					mockResponse(
 						{ code: 'rest_no_route', message: 'No route' },
@@ -393,7 +478,10 @@ describe('setup wizard', () => {
 		});
 
 		it('exits with generic connection error on non-API auth failure', async () => {
-			fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
+				.mockRejectedValueOnce(new Error('ECONNREFUSED'));
 
 			const { deps, errors } = createTestDeps(
 				['https://example.com', 'admin', 'xxxx xxxx xxxx'],
@@ -413,6 +501,8 @@ describe('setup wizard', () => {
 
 		it('exits with API error message on non-404 sync endpoint failure', async () => {
 			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
 				.mockResolvedValueOnce(
 					mockResponse({
 						id: 1,
@@ -421,7 +511,6 @@ describe('setup wizard', () => {
 						avatar_urls: {},
 					})
 				)
-				.mockResolvedValueOnce(mockResponse({ version: '7.0' }))
 				.mockResolvedValueOnce(
 					mockResponse(
 						{
@@ -455,6 +544,8 @@ describe('setup wizard', () => {
 
 		it('exits with generic sync error on non-API sync endpoint failure', async () => {
 			fetchMock
+				.mockResolvedValueOnce(mockDiscoveryResponse())
+				.mockResolvedValueOnce(mockAuthSupportResponse())
 				.mockResolvedValueOnce(
 					mockResponse({
 						id: 1,

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -26,7 +26,9 @@ const mockListTerms = vi.fn<() => Promise<WPTerm[]>>();
 const mockSearchTerms = vi.fn<() => Promise<WPTerm[]>>();
 const mockCreateTerm = vi.fn<() => Promise<WPTerm>>();
 const mockGetTerms = vi.fn<() => Promise<WPTerm[]>>();
-const mockGetWordPressVersion = vi.fn<() => Promise<string>>();
+const mockCheckAuthSupport = vi
+	.fn<() => Promise<void>>()
+	.mockResolvedValue(undefined);
 const mockCheckNotesSupport = vi.fn<() => Promise<boolean>>();
 const mockListNotes = vi.fn<() => Promise<WPNote[]>>();
 const mockCreateNote = vi.fn<() => Promise<WPNote>>();
@@ -48,30 +50,37 @@ vi.mock('../../src/wordpress/api-client.js', () => {
 	}
 
 	return {
-		WordPressApiClient: vi.fn().mockImplementation(function (
-			this: Record<string, unknown>
-		) {
-			this.validateConnection = mockValidateConnection;
-			this.validateSyncEndpoint = mockValidateSyncEndpoint;
-			this.getPost = mockGetPost;
-			this.listPosts = mockListPosts;
-			this.createPost = mockCreatePost;
-			this.updatePost = mockUpdatePost;
-			this.sendSyncUpdate = mockSendSyncUpdate;
-			this.getBlockTypes = mockGetBlockTypes;
-			this.uploadMedia = mockUploadMedia;
-			this.listTerms = mockListTerms;
-			this.searchTerms = mockSearchTerms;
-			this.createTerm = mockCreateTerm;
-			this.getTerms = mockGetTerms;
-			this.getWordPressVersion = mockGetWordPressVersion;
-			this.checkNotesSupport = mockCheckNotesSupport;
-			this.listNotes = mockListNotes;
-			this.createNote = mockCreateNote;
-			this.updateNote = mockUpdateNote;
-			this.deleteNote = mockDeleteNote;
-			this.request = mockRequest;
-		}),
+		WordPressApiClient: Object.assign(
+			vi.fn().mockImplementation(function (
+				this: Record<string, unknown>
+			) {
+				this.validateConnection = mockValidateConnection;
+				this.validateSyncEndpoint = mockValidateSyncEndpoint;
+				this.getPost = mockGetPost;
+				this.listPosts = mockListPosts;
+				this.createPost = mockCreatePost;
+				this.updatePost = mockUpdatePost;
+				this.sendSyncUpdate = mockSendSyncUpdate;
+				this.getBlockTypes = mockGetBlockTypes;
+				this.uploadMedia = mockUploadMedia;
+				this.listTerms = mockListTerms;
+				this.searchTerms = mockSearchTerms;
+				this.createTerm = mockCreateTerm;
+				this.getTerms = mockGetTerms;
+				this.checkAuthSupport = mockCheckAuthSupport;
+				this.checkNotesSupport = mockCheckNotesSupport;
+				this.listNotes = mockListNotes;
+				this.createNote = mockCreateNote;
+				this.updateNote = mockUpdateNote;
+				this.deleteNote = mockDeleteNote;
+				this.request = mockRequest;
+			}),
+			{
+				discover: vi.fn().mockResolvedValue({
+					restUrl: 'https://example.com/wp-json',
+				}),
+			}
+		),
 		WordPressApiError,
 	};
 });
@@ -214,7 +223,6 @@ describe('SessionManager', () => {
 			queueSize: 0,
 		});
 		mockGetBlockTypes.mockRejectedValue(new Error('Not available'));
-		mockGetWordPressVersion.mockResolvedValue('7.0');
 		mockCheckNotesSupport.mockResolvedValue(false);
 		mockGetTerms.mockResolvedValue([]);
 		mockCommandHandlerStart.mockResolvedValue(false);


### PR DESCRIPTION
## Summary

- **REST API URL discovery**: adds `static async discover(siteUrl)` that fetches the site's home page and extracts the REST API URL from the HTTP `Link` header (primary) or HTML `<link>` tag (fallback), defaulting to `/wp-json` if neither is found or the request fails
- **`?rest_route=` support**: adds `buildApiUrl()` to correctly construct URLs for sites without pretty permalinks, where query params must be merged with `&` instead of `?`
- **Auth method detection**: adds `checkAuthSupport()` that inspects the REST root's `authentication` object before the first authenticated request, giving a clear error if application-passwords aren't available instead of a confusing 401
- **Removes `getWordPressVersion()`** in favour of feature detection (sync endpoint availability, auth support)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` — 1210 tests pass (21 new tests for discovery, auth support, and URL construction)
- [ ] `npm run lint` clean
- [ ] Manual: connect to a WordPress site with pretty permalinks and verify discovery works
- [ ] Manual: connect to a WordPress site without pretty permalinks (`?rest_route=`) if available