### PR TITLE
feat: Add cloud service connection support

### DIFF
--- a/wordpress-plugin/claudaborative-editing.php
+++ b/wordpress-plugin/claudaborative-editing.php
@@ -100,9 +100,18 @@ class Claudaborative_Editing {
 		// @wordpress/sync evaluates its config, so we inline it after
 		// wp-hooks (which loads before wp-sync in the dependency graph).
 		$mcp_connected = REST_Controller::is_mcp_connected_for_user( get_current_user_id() );
+		$cloud_url     = get_option( 'wpce_cloud_url', '' );
+		$cloud_api_key = get_option( 'wpce_cloud_api_key', '' );
+
 		wp_add_inline_script(
 			'wp-hooks',
-			'window.wpceInitialState = ' . wp_json_encode( array( 'mcpConnected' => $mcp_connected ) ) . ';' .
+			'window.wpceInitialState = ' . wp_json_encode(
+				array(
+					'mcpConnected' => $mcp_connected,
+					'cloudUrl'     => $cloud_url,
+					'cloudApiKey'  => $cloud_api_key,
+				)
+			) . ';' .
 			( $mcp_connected
 				? "wp.hooks.addFilter('sync.pollingManager.pollingInterval','claudaborative-editing/polling-interval',function(){return 1000;});"
 				: ''

--- a/wordpress-plugin/includes/class-rest-controller.php
+++ b/wordpress-plugin/includes/class-rest-controller.php
@@ -835,10 +835,11 @@ class REST_Controller extends \WP_REST_Controller {
 	 */
 	public function get_cloud_settings() {
 		$cloud_url = get_option( 'wpce_cloud_url', '' );
+		$api_key   = get_option( 'wpce_cloud_api_key', '' );
 
 		return rest_ensure_response(
 			array(
-				'configured' => ! empty( $cloud_url ),
+				'configured' => ! empty( $cloud_url ) && ! empty( $api_key ),
 				'cloud_url'  => $cloud_url,
 			)
 		);

--- a/wordpress-plugin/includes/class-rest-controller.php
+++ b/wordpress-plugin/includes/class-rest-controller.php
@@ -182,6 +182,7 @@ class REST_Controller extends \WP_REST_Controller {
 							'type'              => 'string',
 							'format'            => 'uri',
 							'sanitize_callback' => 'sanitize_url',
+							'validate_callback' => array( $this, 'validate_cloud_url' ),
 						),
 						'api_key'   => array(
 							'required'          => true,
@@ -264,9 +265,10 @@ class REST_Controller extends \WP_REST_Controller {
 	/**
 	 * Permission check: user can manage options (administrator).
 	 *
+	 * @param \WP_REST_Request $request The request object.
 	 * @return bool True if permitted.
 	 */
-	public function manage_options_permissions() {
+	public function manage_options_permissions( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -361,6 +363,46 @@ class REST_Controller extends \WP_REST_Controller {
 				),
 				array( 'status' => 400 )
 			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate that the cloud_url uses HTTPS (or HTTP for localhost dev).
+	 *
+	 * The cloud URL is used as a Bearer token destination, so allowing
+	 * plaintext HTTP would risk leaking the API key.
+	 *
+	 * @param string           $value   The parameter value.
+	 * @param \WP_REST_Request $request The request object.
+	 * @param string           $param   The parameter name.
+	 * @return true|\WP_Error True if valid, \WP_Error otherwise.
+	 */
+	public function validate_cloud_url( $value, $request, $param ) {
+		$parsed = wp_parse_url( $value );
+
+		if ( ! $parsed || empty( $parsed['scheme'] ) || empty( $parsed['host'] ) ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'cloud_url must be a valid URL.', 'claudaborative-editing' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$scheme = strtolower( $parsed['scheme'] );
+		$host   = strtolower( $parsed['host'] );
+
+		// Allow http:// only for localhost development.
+		if ( 'https' !== $scheme ) {
+			$localhost_hosts = array( 'localhost', '127.0.0.1', '::1' );
+			if ( 'http' !== $scheme || ! in_array( $host, $localhost_hosts, true ) ) {
+				return new \WP_Error(
+					'rest_invalid_param',
+					__( 'cloud_url must use HTTPS (HTTP is only allowed for localhost).', 'claudaborative-editing' ),
+					array( 'status' => 400 )
+				);
+			}
 		}
 
 		return true;

--- a/wordpress-plugin/includes/class-rest-controller.php
+++ b/wordpress-plugin/includes/class-rest-controller.php
@@ -163,6 +163,41 @@ class REST_Controller extends \WP_REST_Controller {
 			)
 		);
 
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/cloud',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_cloud_settings' ),
+					'permission_callback' => array( $this, 'edit_posts_permissions' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'update_cloud_settings' ),
+					'permission_callback' => array( $this, 'manage_options_permissions' ),
+					'args'                => array(
+						'cloud_url' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'format'            => 'uri',
+							'sanitize_callback' => 'sanitize_url',
+						),
+						'api_key'   => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => \WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_cloud_settings' ),
+					'permission_callback' => array( $this, 'manage_options_permissions' ),
+				),
+			)
+		);
+
 		// Lightweight endpoints for the core-data entity resolver.
 		// The collection endpoint returns an empty array so getEntityRecords()
 		// succeeds and triggers collection Yjs sync for a per-user command
@@ -224,6 +259,15 @@ class REST_Controller extends \WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Permission check: user can manage options (administrator).
+	 *
+	 * @return bool True if permitted.
+	 */
+	public function manage_options_permissions() {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -736,6 +780,54 @@ class REST_Controller extends \WP_REST_Controller {
 	 */
 	public function get_sync_entity_single( $request ) {
 		return rest_ensure_response( array( 'id' => (int) $request['id'] ) );
+	}
+
+	/**
+	 * GET /wpce/v1/cloud — return cloud connection settings.
+	 *
+	 * Returns whether the cloud is configured and the cloud URL.
+	 * The API key is intentionally omitted — it is passed to the editor
+	 * via wpceInitialState (only visible to authenticated users).
+	 *
+	 * @return \WP_REST_Response Response.
+	 */
+	public function get_cloud_settings() {
+		$cloud_url = get_option( 'wpce_cloud_url', '' );
+
+		return rest_ensure_response(
+			array(
+				'configured' => ! empty( $cloud_url ),
+				'cloud_url'  => $cloud_url,
+			)
+		);
+	}
+
+	/**
+	 * POST /wpce/v1/cloud — store cloud service URL and API key.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response Response.
+	 */
+	public function update_cloud_settings( $request ) {
+		$cloud_url = $request->get_param( 'cloud_url' );
+		$api_key   = $request->get_param( 'api_key' );
+
+		update_option( 'wpce_cloud_url', $cloud_url, false );
+		update_option( 'wpce_cloud_api_key', $api_key, false );
+
+		return rest_ensure_response( array( 'ok' => true ) );
+	}
+
+	/**
+	 * DELETE /wpce/v1/cloud — remove cloud service settings.
+	 *
+	 * @return \WP_REST_Response Response.
+	 */
+	public function delete_cloud_settings() {
+		delete_option( 'wpce_cloud_url' );
+		delete_option( 'wpce_cloud_api_key' );
+
+		return rest_ensure_response( array( 'ok' => true ) );
 	}
 
 	/**

--- a/wordpress-plugin/src/cloud/connect.ts
+++ b/wordpress-plugin/src/cloud/connect.ts
@@ -1,0 +1,59 @@
+/**
+ * Cloud connection helpers.
+ *
+ * Provides functions to connect to the Claudaborative Cloud service and
+ * to check whether cloud settings are configured in wpceInitialState.
+ */
+
+/** Shape of the cloud-related fields on wpceInitialState. */
+interface WpceCloudState {
+	cloudUrl?: string;
+	cloudApiKey?: string;
+}
+
+/**
+ * Read the cloud fields from wpceInitialState (set server-side via
+ * wp_add_inline_script).
+ */
+function getCloudState(): WpceCloudState | undefined {
+	return (window as Window & { wpceInitialState?: WpceCloudState })
+		.wpceInitialState;
+}
+
+/**
+ * Check whether cloud settings (URL and API key) are present.
+ *
+ * @return True when both cloudUrl and cloudApiKey are non-empty.
+ */
+export function isCloudConfigured(): boolean {
+	const state = getCloudState();
+	return Boolean(state?.cloudUrl && state?.cloudApiKey);
+}
+
+/**
+ * Connect to the Claudaborative Cloud service when the editor loads.
+ *
+ * Sends the site's API key so the cloud service creates a SessionManager
+ * that will connect back via the Yjs sync protocol.
+ */
+export function connectToCloud(): void {
+	const state = getCloudState();
+
+	if (!state?.cloudUrl || !state?.cloudApiKey) {
+		return;
+	}
+
+	const url = `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`;
+
+	fetch(url, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${state.cloudApiKey}`,
+		},
+		// No credentials -- cross-origin request with API key auth.
+		mode: 'cors',
+	}).catch(() => {
+		// Best-effort: if the cloud service is down, the user still has
+		// the local editor. The cloud service's idle timeout handles cleanup.
+	});
+}

--- a/wordpress-plugin/src/cloud/connect.ts
+++ b/wordpress-plugin/src/cloud/connect.ts
@@ -43,6 +43,19 @@ export function connectToCloud(): void {
 		return;
 	}
 
+	// Refuse to send the API key over plaintext (allow http://localhost for dev).
+	try {
+		const parsed = new URL(state.cloudUrl);
+		const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
+			parsed.hostname
+		);
+		if (parsed.protocol !== 'https:' && !isLocalhost) {
+			return;
+		}
+	} catch {
+		return;
+	}
+
 	const url = `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`;
 
 	fetch(url, {

--- a/wordpress-plugin/src/cloud/test/connect.test.ts
+++ b/wordpress-plugin/src/cloud/test/connect.test.ts
@@ -139,6 +139,62 @@ describe('cloud/connect', () => {
 			);
 		});
 
+		it('does not call fetch when cloudUrl uses plain HTTP', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://cloud.example.com',
+				cloudApiKey: 'key-insecure',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('allows HTTP for localhost development', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://localhost:8080',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('allows HTTP for 127.0.0.1 development', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://127.0.0.1:3000',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not call fetch when cloudUrl is an invalid URL', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'not-a-url',
+				cloudApiKey: 'key-bad',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
 		it('silently catches fetch errors', async () => {
 			(window as any).wpceInitialState = {
 				cloudUrl: 'https://claudaborative.cloud',

--- a/wordpress-plugin/src/cloud/test/connect.test.ts
+++ b/wordpress-plugin/src/cloud/test/connect.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the cloud/connect module.
+ */
+
+describe('cloud/connect', () => {
+	let originalFetch: typeof window.fetch;
+	let originalState: unknown;
+
+	beforeEach(() => {
+		originalFetch = window.fetch;
+		originalState = (window as any).wpceInitialState;
+		jest.resetModules();
+	});
+
+	afterEach(() => {
+		window.fetch = originalFetch;
+		if (originalState !== undefined) {
+			(window as any).wpceInitialState = originalState;
+		} else {
+			delete (window as any).wpceInitialState;
+		}
+	});
+
+	describe('isCloudConfigured', () => {
+		it('returns false when wpceInitialState is undefined', () => {
+			delete (window as any).wpceInitialState;
+			const { isCloudConfigured } = require('../connect');
+			expect(isCloudConfigured()).toBe(false);
+		});
+
+		it('returns false when cloudUrl is empty', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: '',
+				cloudApiKey: 'key-123',
+			};
+			const { isCloudConfigured } = require('../connect');
+			expect(isCloudConfigured()).toBe(false);
+		});
+
+		it('returns false when cloudApiKey is empty', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://example.com',
+				cloudApiKey: '',
+			};
+			const { isCloudConfigured } = require('../connect');
+			expect(isCloudConfigured()).toBe(false);
+		});
+
+		it('returns false when both are missing', () => {
+			(window as any).wpceInitialState = {};
+			const { isCloudConfigured } = require('../connect');
+			expect(isCloudConfigured()).toBe(false);
+		});
+
+		it('returns true when both cloudUrl and cloudApiKey are set', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc-123',
+			};
+			const { isCloudConfigured } = require('../connect');
+			expect(isCloudConfigured()).toBe(true);
+		});
+	});
+
+	describe('connectToCloud', () => {
+		it('does not call fetch when cloud is not configured', () => {
+			(window as any).wpceInitialState = {};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('does not call fetch when cloudUrl is missing', () => {
+			(window as any).wpceInitialState = { cloudApiKey: 'key-123' };
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('does not call fetch when cloudApiKey is missing', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://example.com',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('calls fetch with correct URL and headers when configured', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc-123',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://claudaborative.cloud/api/v1/connect',
+				{
+					method: 'POST',
+					headers: {
+						Authorization: 'Bearer key-abc-123',
+					},
+					mode: 'cors',
+				}
+			);
+		});
+
+		it('strips trailing slashes from cloudUrl', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud///',
+				cloudApiKey: 'key-456',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://claudaborative.cloud/api/v1/connect',
+				expect.any(Object)
+			);
+		});
+
+		it('silently catches fetch errors', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-789',
+			};
+			const fetchError = new Error('Network failure');
+			const mockFetch = jest.fn().mockRejectedValue(fetchError);
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+
+			// Should not throw.
+			expect(() => connectToCloud()).not.toThrow();
+
+			// Wait for the catch handler to execute.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	});
+});

--- a/wordpress-plugin/src/components/AiActionsMenu/index.tsx
+++ b/wordpress-plugin/src/components/AiActionsMenu/index.tsx
@@ -35,6 +35,7 @@ import EditFocusModal from '../EditFocusModal';
 import TranslateModal from '../TranslateModal';
 import SetupModal from '../SetupModal';
 import aiActionsStore from '../../store';
+import { isCloudConfigured } from '../../cloud/connect';
 
 import './style.scss';
 
@@ -172,7 +173,7 @@ export default function AiActionsMenu() {
 										)}
 									</MenuItem>
 								</MenuGroup>
-								{!mcpConnected && (
+								{!mcpConnected && !isCloudConfigured() && (
 									<MenuGroup>
 										<div className="wpce-ai-actions-disconnected-notice">
 											<div className="wpce-ai-actions-disconnected-status">

--- a/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
@@ -33,16 +33,16 @@ import { isCloudConfigured } from '../../cloud/connect';
 export default function OnboardingContent() {
 	const { copied, handleCopy } = useCopyToClipboard(SETUP_COMMAND);
 
-	if ( isCloudConfigured() ) {
+	if (isCloudConfigured()) {
 		return (
 			<div className="wpce-onboarding wpce-onboarding-cloud-connecting">
 				<Spinner />
 				<span>
-					{ sprintf(
+					{sprintf(
 						/* translators: %s: Claudaborative Cloud service name */
-						__( 'Connecting to %s\u2026', 'claudaborative-editing' ),
-						__( 'Claudaborative Cloud', 'claudaborative-editing' )
-					) }
+						__('Connecting to %s\u2026', 'claudaborative-editing'),
+						__('Claudaborative Cloud', 'claudaborative-editing')
+					)}
 				</span>
 			</div>
 		);

--- a/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/OnboardingContent.tsx
@@ -8,8 +8,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Button, ExternalLink, Icon } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, ExternalLink, Icon, Spinner } from '@wordpress/components';
 import { cloud, code } from '@wordpress/icons';
 
 /**
@@ -17,18 +17,36 @@ import { cloud, code } from '@wordpress/icons';
  */
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard';
 import { SETUP_COMMAND } from '../../constants';
+import { isCloudConfigured } from '../../cloud/connect';
 // Styles are imported via ConnectionStatus/style.scss to ensure
 // they land in the extracted style-index.css stylesheet.
 
 /**
  * OnboardingContent component.
  *
- * Renders two setup option cards: hosted cloud service and local CLI setup.
+ * When cloud settings are configured, shows a "Connecting..." message
+ * instead of setup instructions. Otherwise renders two setup option
+ * cards: hosted cloud service and local CLI setup.
  *
  * @return Rendered onboarding content.
  */
 export default function OnboardingContent() {
 	const { copied, handleCopy } = useCopyToClipboard(SETUP_COMMAND);
+
+	if ( isCloudConfigured() ) {
+		return (
+			<div className="wpce-onboarding wpce-onboarding-cloud-connecting">
+				<Spinner />
+				<span>
+					{ sprintf(
+						/* translators: %s: Claudaborative Cloud service name */
+						__( 'Connecting to %s\u2026', 'claudaborative-editing' ),
+						__( 'Claudaborative Cloud', 'claudaborative-editing' )
+					) }
+				</span>
+			</div>
+		);
+	}
 
 	return (
 		<div className="wpce-onboarding">

--- a/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/OnboardingContent.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@wordpress/components', () => {
 				'data-icon': icon?.name ?? 'unknown',
 				'data-size': size,
 			}),
+		Spinner: () => createElement('span', { 'data-testid': 'spinner' }),
 	};
 });
 
@@ -56,12 +57,24 @@ import OnboardingContent from '../OnboardingContent';
 const mockedUseCopyToClipboard = useCopyToClipboard as jest.Mock;
 
 describe('OnboardingContent', () => {
+	const originalState = (window as any).wpceInitialState;
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockedUseCopyToClipboard.mockReturnValue({
 			copied: false,
 			handleCopy: mockHandleCopy,
 		});
+		// Ensure no cloud settings by default.
+		delete (window as any).wpceInitialState;
+	});
+
+	afterEach(() => {
+		if (originalState !== undefined) {
+			(window as any).wpceInitialState = originalState;
+		} else {
+			delete (window as any).wpceInitialState;
+		}
 	});
 
 	it('renders the heading text', () => {
@@ -116,5 +129,35 @@ describe('OnboardingContent', () => {
 
 		expect(screen.getByText('Copied!')).toBeTruthy();
 		expect(screen.queryByText('Copy')).toBeNull();
+	});
+
+	describe('when cloud is configured', () => {
+		beforeEach(() => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc-123',
+			};
+		});
+
+		it('shows a connecting message instead of setup instructions', () => {
+			render(<OnboardingContent />);
+
+			expect(
+				screen.getByText(/Connecting to Claudaborative Cloud/)
+			).toBeTruthy();
+			expect(screen.getByTestId('spinner')).toBeTruthy();
+		});
+
+		it('does not render setup option cards', () => {
+			render(<OnboardingContent />);
+
+			expect(
+				screen.queryByText('Get started with one of these options:')
+			).toBeNull();
+			expect(screen.queryByText('Set up locally')).toBeNull();
+			expect(
+				screen.queryByText('Sign up at claudaborative.cloud')
+			).toBeNull();
+		});
 	});
 });

--- a/wordpress-plugin/src/index.ts
+++ b/wordpress-plugin/src/index.ts
@@ -18,6 +18,7 @@ import { registerPlugin } from '@wordpress/plugins';
 // Register the data store (side-effect import).
 import './store';
 
+import { connectToCloud } from './cloud/connect';
 import { initCommandSync } from './sync/command-sync';
 
 // Defer command sync initialization so the post room registers first and
@@ -26,6 +27,10 @@ import { initCommandSync } from './sync/command-sync';
 // detection. The per-user command room should not be primary because the
 // post room is the natural primary for editor collaboration.
 setTimeout(() => void initCommandSync(), 0);
+
+// Notify the cloud service (if configured) so it creates a SessionManager
+// that will connect back to this site via Yjs sync.
+connectToCloud();
 
 import AiActionsMenu from './components/AiActionsMenu';
 import ConnectionStatus from './components/ConnectionStatus';

--- a/wordpress-plugin/src/sync/command-sync.ts
+++ b/wordpress-plugin/src/sync/command-sync.ts
@@ -539,7 +539,11 @@ export function isMcpConnected(): boolean {
 	// Used only until awareness warms up (receives its first remote state).
 	const initialState = (
 		window as Window & {
-			wpceInitialState?: { mcpConnected?: boolean };
+			wpceInitialState?: {
+				mcpConnected?: boolean;
+				cloudUrl?: string;
+				cloudApiKey?: string;
+			};
 		}
 	).wpceInitialState;
 	return initialState?.mcpConnected ?? false;

--- a/wordpress-plugin/tests/RestControllerTest.php
+++ b/wordpress-plugin/tests/RestControllerTest.php
@@ -1735,6 +1735,22 @@ class RestControllerTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * GET /wpce/v1/cloud returns configured:false when the URL is set but
+	 * the API key is missing (partial configuration).
+	 */
+	public function test_get_cloud_settings_partial_url_only() {
+		update_option( 'wpce_cloud_url', 'https://cloud.example.com', false );
+		delete_option( 'wpce_cloud_api_key' );
+
+		$request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['configured'] );
+		$this->assertSame( 'https://cloud.example.com', $data['cloud_url'] );
+	}
+
+	/**
 	 * An editor can read cloud settings (requires edit_posts).
 	 */
 	public function test_get_cloud_settings_editor_allowed() {

--- a/wordpress-plugin/tests/RestControllerTest.php
+++ b/wordpress-plugin/tests/RestControllerTest.php
@@ -1902,6 +1902,24 @@ class RestControllerTest extends \WP_UnitTestCase {
 		$this->assertSame( 400, $response->get_status() );
 	}
 
+	/**
+	 * validate_cloud_url rejects a URL without a scheme or host.
+	 *
+	 * Called directly because sanitize_url (which runs before the
+	 * validate_callback in REST dispatch) normalises malformed values
+	 * before the validator sees them.
+	 */
+	public function test_validate_cloud_url_rejects_missing_scheme_and_host() {
+		$controller = new REST_Controller();
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+
+		$result = $controller->validate_cloud_url( '/just-a-path', $request, 'cloud_url' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
+	}
+
 	// -------------------------------------------------------------------------
 	// DELETE /wpce/v1/cloud
 	// -------------------------------------------------------------------------

--- a/wordpress-plugin/tests/RestControllerTest.php
+++ b/wordpress-plugin/tests/RestControllerTest.php
@@ -25,6 +25,13 @@ class RestControllerTest extends \WP_UnitTestCase {
 	private static $editor2_id;
 
 	/**
+	 * Administrator user ID (for manage_options tests).
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
 	 * Subscriber user ID (for permission-denied tests).
 	 *
 	 * @var int
@@ -52,6 +59,10 @@ class RestControllerTest extends \WP_UnitTestCase {
 		/** @var int $editor2_id */
 		$editor2_id       = $factory->user->create( [ 'role' => 'editor' ] );
 		self::$editor2_id = $editor2_id;
+
+		/** @var int $admin_id */
+		$admin_id       = $factory->user->create( [ 'role' => 'administrator' ] );
+		self::$admin_id = $admin_id;
 
 		/** @var int $subscriber_id */
 		$subscriber_id       = $factory->user->create( [ 'role' => 'subscriber' ] );
@@ -1601,6 +1612,58 @@ class RestControllerTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * enqueue_editor_assets includes cloudUrl and cloudApiKey in wpceInitialState
+	 * when cloud options are configured.
+	 */
+	public function test_enqueue_editor_assets_includes_cloud_settings() {
+		$this->ensure_asset_file();
+		delete_transient( 'wpce_mcp_last_seen_' . self::$editor_id );
+
+		update_option( 'wpce_cloud_url', 'https://cloud.example.com', false );
+		update_option( 'wpce_cloud_api_key', 'test-key-123', false );
+
+		$GLOBALS['wp_scripts'] = null;
+		wp_default_scripts( wp_scripts() );
+
+		\Claudaborative_Editing::enqueue_editor_assets();
+
+		$scripts = wp_scripts();
+		$inline  = $scripts->get_data( 'wp-hooks', 'after' );
+
+		$this->assertIsArray( $inline );
+
+		$joined = implode( "\n", $inline );
+		$this->assertStringContainsString( '"cloudUrl":"https:\/\/cloud.example.com"', $joined );
+		$this->assertStringContainsString( '"cloudApiKey":"test-key-123"', $joined );
+	}
+
+	/**
+	 * enqueue_editor_assets sets empty cloudUrl and cloudApiKey when cloud
+	 * options are not configured.
+	 */
+	public function test_enqueue_editor_assets_empty_cloud_settings() {
+		$this->ensure_asset_file();
+		delete_transient( 'wpce_mcp_last_seen_' . self::$editor_id );
+
+		delete_option( 'wpce_cloud_url' );
+		delete_option( 'wpce_cloud_api_key' );
+
+		$GLOBALS['wp_scripts'] = null;
+		wp_default_scripts( wp_scripts() );
+
+		\Claudaborative_Editing::enqueue_editor_assets();
+
+		$scripts = wp_scripts();
+		$inline  = $scripts->get_data( 'wp-hooks', 'after' );
+
+		$this->assertIsArray( $inline );
+
+		$joined = implode( "\n", $inline );
+		$this->assertStringContainsString( '"cloudUrl":""', $joined );
+		$this->assertStringContainsString( '"cloudApiKey":""', $joined );
+	}
+
+	/**
 	 * enqueue_editor_assets sets mcpConnected: true and adds the polling
 	 * interval filter when MCP IS connected.
 	 */
@@ -1628,5 +1691,300 @@ class RestControllerTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '"mcpConnected":true', $joined );
 		$this->assertStringContainsString( 'pollingInterval', $joined );
 		$this->assertStringContainsString( 'return 1000', $joined );
+	}
+
+	// -------------------------------------------------------------------------
+	// GET /wpce/v1/cloud
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GET /wpce/v1/cloud returns configured:false when no options are set.
+	 */
+	public function test_get_cloud_settings_unconfigured() {
+		delete_option( 'wpce_cloud_url' );
+		delete_option( 'wpce_cloud_api_key' );
+
+		$request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['configured'] );
+		$this->assertSame( '', $data['cloud_url'] );
+		// API key should NOT be in the GET response.
+		$this->assertArrayNotHasKey( 'api_key', $data );
+	}
+
+	/**
+	 * GET /wpce/v1/cloud returns configured:true and the URL when options are set.
+	 */
+	public function test_get_cloud_settings_configured() {
+		update_option( 'wpce_cloud_url', 'https://cloud.example.com', false );
+		update_option( 'wpce_cloud_api_key', 'secret-key', false );
+
+		$request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['configured'] );
+		$this->assertSame( 'https://cloud.example.com', $data['cloud_url'] );
+		$this->assertArrayNotHasKey( 'api_key', $data );
+	}
+
+	/**
+	 * An editor can read cloud settings (requires edit_posts).
+	 */
+	public function test_get_cloud_settings_editor_allowed() {
+		$request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * A subscriber cannot read cloud settings.
+	 */
+	public function test_get_cloud_settings_subscriber_denied() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	// -------------------------------------------------------------------------
+	// POST /wpce/v1/cloud
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An admin can store cloud settings via POST.
+	 */
+	public function test_update_cloud_settings_admin_allowed() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'https://cloud.example.com',
+				'api_key'   => 'my-api-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['ok'] );
+
+		// Verify options were persisted.
+		$this->assertSame( 'https://cloud.example.com', get_option( 'wpce_cloud_url' ) );
+		$this->assertSame( 'my-api-key', get_option( 'wpce_cloud_api_key' ) );
+	}
+
+	/**
+	 * An editor (non-admin) cannot store cloud settings.
+	 */
+	public function test_update_cloud_settings_editor_denied() {
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'https://cloud.example.com',
+				'api_key'   => 'my-api-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * A subscriber cannot store cloud settings.
+	 */
+	public function test_update_cloud_settings_subscriber_denied() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'https://cloud.example.com',
+				'api_key'   => 'my-api-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * POST /wpce/v1/cloud requires both cloud_url and api_key.
+	 */
+	public function test_update_cloud_settings_missing_params() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params( [ 'cloud_url' => 'https://cloud.example.com' ] );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * POST /wpce/v1/cloud rejects plain HTTP cloud_url (non-localhost).
+	 */
+	public function test_update_cloud_settings_rejects_http() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'http://cloud.example.com',
+				'api_key'   => 'my-api-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * POST /wpce/v1/cloud allows http://localhost for development.
+	 */
+	public function test_update_cloud_settings_allows_localhost_http() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'http://localhost:8080',
+				'api_key'   => 'dev-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * POST /wpce/v1/cloud allows http://127.0.0.1 for development.
+	 */
+	public function test_update_cloud_settings_allows_127_http() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'http://127.0.0.1:3000',
+				'api_key'   => 'dev-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * POST /wpce/v1/cloud rejects non-HTTP/HTTPS schemes.
+	 */
+	public function test_update_cloud_settings_rejects_ftp_scheme() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$request->set_body_params(
+			[
+				'cloud_url' => 'ftp://cloud.example.com',
+				'api_key'   => 'my-api-key',
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	// -------------------------------------------------------------------------
+	// DELETE /wpce/v1/cloud
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An admin can delete cloud settings via DELETE.
+	 */
+	public function test_delete_cloud_settings_admin_allowed() {
+		update_option( 'wpce_cloud_url', 'https://cloud.example.com', false );
+		update_option( 'wpce_cloud_api_key', 'secret-key', false );
+
+		wp_set_current_user( self::$admin_id );
+
+		$request  = new \WP_REST_Request( 'DELETE', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['ok'] );
+
+		// Verify options were removed.
+		$this->assertFalse( get_option( 'wpce_cloud_url' ) );
+		$this->assertFalse( get_option( 'wpce_cloud_api_key' ) );
+	}
+
+	/**
+	 * An editor (non-admin) cannot delete cloud settings.
+	 */
+	public function test_delete_cloud_settings_editor_denied() {
+		$request  = new \WP_REST_Request( 'DELETE', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * A subscriber cannot delete cloud settings.
+	 */
+	public function test_delete_cloud_settings_subscriber_denied() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request  = new \WP_REST_Request( 'DELETE', '/wpce/v1/cloud' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Full round-trip: POST → GET → DELETE → GET verifies the complete
+	 * cloud settings lifecycle.
+	 */
+	public function test_cloud_settings_round_trip() {
+		wp_set_current_user( self::$admin_id );
+
+		// POST — store settings.
+		$post_request = new \WP_REST_Request( 'POST', '/wpce/v1/cloud' );
+		$post_request->set_body_params(
+			[
+				'cloud_url' => 'https://round-trip.example.com',
+				'api_key'   => 'rt-key',
+			]
+		);
+		$post_response = rest_get_server()->dispatch( $post_request );
+		$this->assertSame( 200, $post_response->get_status() );
+
+		// GET — verify settings are returned.
+		$get_request  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$get_response = rest_get_server()->dispatch( $get_request );
+		$get_data     = $get_response->get_data();
+
+		$this->assertTrue( $get_data['configured'] );
+		$this->assertSame( 'https://round-trip.example.com', $get_data['cloud_url'] );
+
+		// DELETE — remove settings.
+		$del_request  = new \WP_REST_Request( 'DELETE', '/wpce/v1/cloud' );
+		$del_response = rest_get_server()->dispatch( $del_request );
+		$this->assertSame( 200, $del_response->get_status() );
+
+		// GET — verify settings are gone.
+		$get_request2  = new \WP_REST_Request( 'GET', '/wpce/v1/cloud' );
+		$get_response2 = rest_get_server()->dispatch( $get_request2 );
+		$get_data2     = $get_response2->get_data();
+
+		$this->assertFalse( $get_data2['configured'] );
+		$this->assertSame( '', $get_data2['cloud_url'] );
 	}
 }


### PR DESCRIPTION
## Summary

- **REST endpoints**: `POST/GET/DELETE /wpce/v1/cloud` — the cloud service pushes its URL and API key to the plugin during the setup wizard
- **Editor JS**: on editor load, if cloud settings exist, calls `POST {cloudUrl}/api/v1/connect` with the API key — this triggers the cloud service to create a SessionManager and connect via Yjs sync
- **Onboarding UI**: shows "Connecting to Claudaborative Cloud..." spinner when cloud is configured, hides setup modal

Companion PR: pento/claudaborative-cloud#5

## Test plan

- [ ] Cloud setup wizard auto-pushes settings to plugin
- [ ] Opening editor triggers cloud connect call
- [ ] MCP connection detected via Yjs after cloud connects
- [ ] Onboarding content shows spinner instead of setup instructions
- [ ] Setup modal does not appear when cloud is configured
- [ ] DELETE /wpce/v1/cloud removes settings