### PR TITLE
fix: poll cloud reconnect when MCP session disconnects

### DIFF
--- a/wordpress-plugin/src/cloud/connect.ts
+++ b/wordpress-plugin/src/cloud/connect.ts
@@ -31,16 +31,21 @@ export function isCloudConfigured(): boolean {
 }
 
 /**
- * Connect to the Claudaborative Cloud service when the editor loads.
+ * Validate cloud state and build a connect request.
  *
- * Sends the site's API key so the cloud service creates a SessionManager
- * that will connect back via the Yjs sync protocol.
+ * Shared by connectToCloud() and reconnectToCloud() to avoid
+ * duplicating URL validation and fetch option construction.
+ *
+ * @return The URL and fetch options, or null when the request should be skipped.
  */
-export function connectToCloud(): void {
+function buildConnectRequest(): {
+	url: string;
+	options: RequestInit;
+} | null {
 	const state = getCloudState();
 
 	if (!state?.cloudUrl || !state?.cloudApiKey) {
-		return;
+		return null;
 	}
 
 	// Refuse to send the API key over plaintext (allow http://localhost for dev).
@@ -50,22 +55,39 @@ export function connectToCloud(): void {
 			parsed.hostname
 		);
 		if (parsed.protocol !== 'https:' && !isLocalhost) {
-			return;
+			return null;
 		}
 	} catch {
+		return null;
+	}
+
+	return {
+		url: `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`,
+		options: {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${state.cloudApiKey}`,
+			},
+			// No credentials -- cross-origin request with API key auth.
+			mode: 'cors',
+			credentials: 'omit',
+		},
+	};
+}
+
+/**
+ * Connect to the Claudaborative Cloud service when the editor loads.
+ *
+ * Sends the site's API key so the cloud service creates a SessionManager
+ * that will connect back via the Yjs sync protocol.
+ */
+export function connectToCloud(): void {
+	const request = buildConnectRequest();
+	if (!request) {
 		return;
 	}
 
-	const url = `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`;
-
-	fetch(url, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${state.cloudApiKey}`,
-		},
-		// No credentials -- cross-origin request with API key auth.
-		mode: 'cors',
-	}).catch(() => {
+	fetch(request.url, request.options).catch(() => {
 		// Best-effort: if the cloud service is down, the user still has
 		// the local editor. The cloud service's idle timeout handles cleanup.
 	});
@@ -80,34 +102,13 @@ export function connectToCloud(): void {
  * @return True if the request succeeded, false otherwise.
  */
 export async function reconnectToCloud(): Promise<boolean> {
-	const state = getCloudState();
-
-	if (!state?.cloudUrl || !state?.cloudApiKey) {
+	const request = buildConnectRequest();
+	if (!request) {
 		return false;
 	}
 
 	try {
-		const parsed = new URL(state.cloudUrl);
-		const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
-			parsed.hostname
-		);
-		if (parsed.protocol !== 'https:' && !isLocalhost) {
-			return false;
-		}
-	} catch {
-		return false;
-	}
-
-	const url = `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`;
-
-	try {
-		const response = await fetch(url, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${state.cloudApiKey}`,
-			},
-			mode: 'cors',
-		});
+		const response = await fetch(request.url, request.options);
 		return response.ok;
 	} catch {
 		return false;

--- a/wordpress-plugin/src/cloud/connect.ts
+++ b/wordpress-plugin/src/cloud/connect.ts
@@ -70,3 +70,46 @@ export function connectToCloud(): void {
 		// the local editor. The cloud service's idle timeout handles cleanup.
 	});
 }
+
+/**
+ * Reconnect to the Claudaborative Cloud service.
+ *
+ * Same as connectToCloud() but returns a promise so callers can
+ * poll on a schedule (e.g., after detecting an MCP disconnect).
+ *
+ * @return True if the request succeeded, false otherwise.
+ */
+export async function reconnectToCloud(): Promise<boolean> {
+	const state = getCloudState();
+
+	if (!state?.cloudUrl || !state?.cloudApiKey) {
+		return false;
+	}
+
+	try {
+		const parsed = new URL(state.cloudUrl);
+		const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
+			parsed.hostname
+		);
+		if (parsed.protocol !== 'https:' && !isLocalhost) {
+			return false;
+		}
+	} catch {
+		return false;
+	}
+
+	const url = `${state.cloudUrl.replace(/\/+$/, '')}/api/v1/connect`;
+
+	try {
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${state.cloudApiKey}`,
+			},
+			mode: 'cors',
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}

--- a/wordpress-plugin/src/cloud/test/connect.test.ts
+++ b/wordpress-plugin/src/cloud/test/connect.test.ts
@@ -118,6 +118,7 @@ describe('cloud/connect', () => {
 						Authorization: 'Bearer key-abc-123',
 					},
 					mode: 'cors',
+					credentials: 'omit',
 				}
 			);
 		});
@@ -307,6 +308,78 @@ describe('cloud/connect', () => {
 
 			expect(result).toBe(false);
 			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('allows HTTP for localhost development', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://localhost:8080',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('allows HTTP for 127.0.0.1 development', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://127.0.0.1:3000',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('strips trailing slashes from cloudUrl', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud///',
+				cloudApiKey: 'key-456',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			await reconnectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://claudaborative.cloud/api/v1/connect',
+				expect.any(Object)
+			);
+		});
+
+		it('includes credentials: omit in fetch options', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			await reconnectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ credentials: 'omit' })
+			);
 		});
 	});
 });

--- a/wordpress-plugin/src/cloud/test/connect.test.ts
+++ b/wordpress-plugin/src/cloud/test/connect.test.ts
@@ -213,4 +213,100 @@ describe('cloud/connect', () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 	});
+
+	describe('reconnectToCloud', () => {
+		it('returns true when fetch succeeds', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://claudaborative.cloud/api/v1/connect',
+				expect.objectContaining({ method: 'POST' })
+			);
+		});
+
+		it('returns false when fetch fails', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockRejectedValue(new Error('Network failure'));
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when response is not ok', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'https://claudaborative.cloud',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: false, status: 502 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false when not configured', async () => {
+			(window as any).wpceInitialState = {};
+			const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(false);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('refuses non-HTTPS URLs', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://cloud.example.com',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(false);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('returns false when URL is invalid', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'not-a-url',
+				cloudApiKey: 'key-abc',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(false);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/wordpress-plugin/src/cloud/test/connect.test.ts
+++ b/wordpress-plugin/src/cloud/test/connect.test.ts
@@ -182,6 +182,20 @@ describe('cloud/connect', () => {
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
 
+		it('allows HTTP for [::1] IPv6 loopback development', () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://[::1]:3000',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest.fn().mockResolvedValue({});
+			window.fetch = mockFetch;
+
+			const { connectToCloud } = require('../connect');
+			connectToCloud();
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
 		it('does not call fetch when cloudUrl is an invalid URL', () => {
 			(window as any).wpceInitialState = {
 				cloudUrl: 'not-a-url',
@@ -330,6 +344,23 @@ describe('cloud/connect', () => {
 		it('allows HTTP for 127.0.0.1 development', async () => {
 			(window as any).wpceInitialState = {
 				cloudUrl: 'http://127.0.0.1:3000',
+				cloudApiKey: 'key-dev',
+			};
+			const mockFetch = jest
+				.fn()
+				.mockResolvedValue({ ok: true, status: 200 });
+			window.fetch = mockFetch;
+
+			const { reconnectToCloud } = require('../connect');
+			const result = await reconnectToCloud();
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('allows HTTP for [::1] IPv6 loopback development', async () => {
+			(window as any).wpceInitialState = {
+				cloudUrl: 'http://[::1]:3000',
 				cloudApiKey: 'key-dev',
 			};
 			const mockFetch = jest

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -131,15 +131,37 @@ export default function ConnectionStatus() {
 	// Poll reconnectToCloud when MCP disconnects after having been connected.
 	// This tells the cloud server to re-establish the SessionManager so
 	// startup recovery can pick up in-flight commands.
+	// Uses a self-scheduling setTimeout loop so that a slow/hanging fetch
+	// never causes overlapping requests (unlike setInterval).
 	useEffect(() => {
 		if (mcpConnected || !wasConnectedRef.current) {
 			return;
 		}
 
-		// Fire immediately, then every 10 seconds.
-		void reconnectToCloud();
-		const interval = setInterval(() => void reconnectToCloud(), 10_000);
-		return () => clearInterval(interval);
+		let cancelled = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+
+		const poll = async (): Promise<void> => {
+			if (cancelled) {
+				return;
+			}
+
+			await reconnectToCloud();
+
+			if (!cancelled) {
+				timeout = setTimeout(() => void poll(), 10_000);
+			}
+		};
+
+		// Fire immediately, then wait 10 seconds after each completed attempt.
+		void poll();
+
+		return () => {
+			cancelled = true;
+			if (timeout) {
+				clearTimeout(timeout);
+			}
+		};
 	}, [mcpConnected]);
 
 	const [footerEl, setFooterEl] = useState<Element | null>(null);

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -28,6 +28,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMcpStatus } from '../../hooks/use-mcp-status';
 import { useCommands } from '../../hooks/use-commands';
 import { getCommandProgressLabel } from '../../utils/command-i18n';
+import { reconnectToCloud } from '../../cloud/connect';
 import aiActionsStore from '../../store';
 import SparkleIcon from '../SparkleIcon';
 import OnboardingContent from './OnboardingContent';
@@ -125,6 +126,20 @@ export default function ConnectionStatus() {
 		if (mcpConnected) {
 			wasConnectedRef.current = true;
 		}
+	}, [mcpConnected]);
+
+	// Poll reconnectToCloud when MCP disconnects after having been connected.
+	// This tells the cloud server to re-establish the SessionManager so
+	// startup recovery can pick up in-flight commands.
+	useEffect(() => {
+		if (mcpConnected || !wasConnectedRef.current) {
+			return;
+		}
+
+		// Fire immediately, then every 10 seconds.
+		void reconnectToCloud();
+		const interval = setInterval(() => void reconnectToCloud(), 10_000);
+		return () => clearInterval(interval);
 	}, [mcpConnected]);
 
 	const [footerEl, setFooterEl] = useState<Element | null>(null);

--- a/wordpress-plugin/src/components/ConnectionStatus/index.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/index.tsx
@@ -142,10 +142,6 @@ export default function ConnectionStatus() {
 		let timeout: ReturnType<typeof setTimeout> | undefined;
 
 		const poll = async (): Promise<void> => {
-			if (cancelled) {
-				return;
-			}
-
 			await reconnectToCloud();
 
 			if (!cancelled) {

--- a/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConnectionStatus/test/index.test.tsx
@@ -64,6 +64,12 @@ jest.mock('../../../hooks/use-commands', () => ({
 	useCommands: jest.fn(),
 }));
 
+const mockReconnectToCloud = jest.fn().mockResolvedValue(true);
+jest.mock('../../../cloud/connect', () => ({
+	reconnectToCloud: (...args: unknown[]) => mockReconnectToCloud(...args),
+	isCloudConfigured: jest.fn(() => false),
+}));
+
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -675,5 +681,97 @@ describe('ConnectionStatus', () => {
 			.getByTestId('popover')
 			.querySelector('.wpce-footer-status-tooltip-onboarding');
 		expect(tooltip).toBeTruthy();
+	});
+
+	// --- Reconnect polling ---
+
+	it('polls reconnectToCloud when MCP disconnects after being connected', async () => {
+		jest.useFakeTimers();
+
+		try {
+			// Start connected
+			mockedUseMcpStatus.mockReturnValue({
+				mcpConnected: true,
+				mcpLastSeenAt: null,
+				isLoading: false,
+				error: null,
+			});
+
+			const { rerender } = await act(async () =>
+				render(<ConnectionStatus />)
+			);
+
+			// Now disconnect
+			mockedUseMcpStatus.mockReturnValue({
+				mcpConnected: false,
+				mcpLastSeenAt: null,
+				isLoading: false,
+				error: null,
+			});
+
+			await act(async () => rerender(<ConnectionStatus />));
+
+			// Should have called reconnectToCloud immediately
+			expect(mockReconnectToCloud).toHaveBeenCalledTimes(1);
+
+			// Advance 10 seconds — should poll again
+			await act(async () => jest.advanceTimersByTime(10_000));
+			expect(mockReconnectToCloud).toHaveBeenCalledTimes(2);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('stops polling when MCP reconnects', async () => {
+		jest.useFakeTimers();
+
+		try {
+			// Start connected
+			mockedUseMcpStatus.mockReturnValue({
+				mcpConnected: true,
+				mcpLastSeenAt: null,
+				isLoading: false,
+				error: null,
+			});
+
+			const { rerender } = await act(async () =>
+				render(<ConnectionStatus />)
+			);
+
+			// Disconnect
+			mockedUseMcpStatus.mockReturnValue({
+				mcpConnected: false,
+				mcpLastSeenAt: null,
+				isLoading: false,
+				error: null,
+			});
+			await act(async () => rerender(<ConnectionStatus />));
+
+			const callsAfterDisconnect = mockReconnectToCloud.mock.calls.length;
+
+			// Reconnect
+			mockedUseMcpStatus.mockReturnValue({
+				mcpConnected: true,
+				mcpLastSeenAt: null,
+				isLoading: false,
+				error: null,
+			});
+			await act(async () => rerender(<ConnectionStatus />));
+
+			// Advance time — should NOT poll anymore
+			await act(async () => jest.advanceTimersByTime(30_000));
+			expect(mockReconnectToCloud.mock.calls.length).toBe(
+				callsAfterDisconnect
+			);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('does not poll reconnectToCloud on initial disconnect (never connected)', async () => {
+		// mcpConnected starts as false, wasConnectedRef is false
+		await act(async () => render(<ConnectionStatus />));
+
+		expect(mockReconnectToCloud).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `reconnectToCloud()` async function that hits the cloud service's `/api/v1/connect` endpoint to re-establish the SessionManager after a disconnect.
- The `ConnectionStatus` component now polls `reconnectToCloud()` every 10 seconds when the MCP session drops after having been connected, stopping when the connection is restored.
- Includes tests for both the reconnect function (success, failure, validation) and the polling lifecycle (start on disconnect, stop on reconnect, skip if never connected).

## Test plan

- [x] All 361 existing tests pass
- [ ] Verify cloud reconnect fires when MCP disconnects (check network tab for `/api/v1/connect` requests)
- [ ] Verify polling stops when MCP reconnects
- [ ] Verify no polling occurs on initial page load when MCP is not yet connected