### PR TITLE
fix: store each command under its own Y.Map key to avoid CRDT clobber

### DIFF
--- a/shared/commands.ts
+++ b/shared/commands.ts
@@ -179,6 +179,20 @@ export const commandKey = (id: number | string): string =>
 export const isCommandKey = (key: string): boolean =>
 	key.startsWith(COMMAND_KEY_PREFIX);
 
+/**
+ * Extract the numeric command id from a `cmd_${id}` key, or `null` if
+ * the key isn't a command key or doesn't carry a valid positive
+ * integer suffix. Readers use this instead of trusting the `id` field
+ * inside the stored value, so a corrupted entry (e.g. `cmd_42` with
+ * `{ id: 43 }`) can't be silently processed under the wrong id.
+ */
+export function commandIdFromKey(key: string): number | null {
+	if (!isCommandKey(key)) return null;
+	const raw = key.slice(COMMAND_KEY_PREFIX.length);
+	if (!/^[1-9][0-9]*$/.test(raw)) return null;
+	return Number(raw);
+}
+
 // --- Conversation types ---
 
 /** A single message in a two-way command conversation. */

--- a/shared/commands.ts
+++ b/shared/commands.ts
@@ -164,6 +164,21 @@ export const VALID_TRANSITIONS: Readonly<
 	awaiting_input: ['running', 'cancelled'],
 } as const;
 
+// --- Y.Doc schema ---
+
+/**
+ * Prefix for per-command keys in the shared command state map. Each
+ * command lives at `cmd_${id}` as an individual Y.Map entry rather than
+ * packed into a single `commands` object — Y.Map tiebreaks can otherwise
+ * silently pick one client's write and discard another's when they both
+ * set the same key.
+ */
+export const COMMAND_KEY_PREFIX = 'cmd_';
+export const commandKey = (id: number | string): string =>
+	`${COMMAND_KEY_PREFIX}${id}`;
+export const isCommandKey = (key: string): boolean =>
+	key.startsWith(COMMAND_KEY_PREFIX);
+
 // --- Conversation types ---
 
 /** A single message in a two-way command conversation. */

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -1812,6 +1812,11 @@ export class SessionManager {
 			message,
 			resultData
 		);
+
+		// Without this, the browser can lag 250-500ms behind the REST
+		// PATCH — long enough for stale cleanup or subsequent writes to
+		// mask the transition.
+		this._syncClient?.flushQueue();
 	}
 
 	/**

--- a/src/wordpress/command-client.ts
+++ b/src/wordpress/command-client.ts
@@ -114,9 +114,10 @@ export class CommandClient {
 
 	/**
 	 * Start observing the provided Y.Map for command changes.
-	 * The concrete shared map is injected by the caller/session layer; this
-	 * method only depends on that map containing a 'commands' key whose value
-	 * is a plain object of command objects keyed by ID.
+	 * The concrete shared map is injected by the caller/session layer;
+	 * each command lives at its own `cmd_${id}` entry and is detected
+	 * via `isCommandKey`. Other keys in the map (e.g. `savedAt`) are
+	 * ignored.
 	 *
 	 * Called by CommandHandler after the command doc is synced.
 	 */
@@ -193,8 +194,9 @@ export class CommandClient {
 	 * Write a command object to the Y.Map after a successful REST call.
 	 * The update will be synced to the browser on the next poll cycle.
 	 *
-	 * Commands are stored under the 'commands' key in the document map,
-	 * matching core-data's entity record structure.
+	 * Each command is stored under its own `cmd_${id}` entry so that
+	 * concurrent writes targeting different commands commute, and
+	 * same-command writes stay causally ordered.
 	 */
 	writeCommandToDoc(command: Command): void {
 		const map = this.commandMap;

--- a/src/wordpress/command-client.ts
+++ b/src/wordpress/command-client.ts
@@ -10,7 +10,27 @@
 import * as Y from 'yjs';
 import { debugLog, isDebugEnabled } from '../debug-log.js';
 import type { WordPressApiClient } from './api-client.js';
-import { type CommandSlug, type CommandStatus } from '../../shared/commands.js';
+import {
+	commandKey,
+	isCommandKey,
+	type CommandSlug,
+	type CommandStatus,
+} from '../../shared/commands.js';
+
+/**
+ * Status progression rank. Writes that would move a command backward
+ * (lower rank) are skipped so a late-arriving stale REST response can't
+ * overwrite a fresh terminal write.
+ */
+const STATUS_RANK: Record<CommandStatus, number> = {
+	pending: 0,
+	running: 1,
+	awaiting_input: 1,
+	completed: 2,
+	failed: 2,
+	cancelled: 2,
+	expired: 2,
+};
 
 /**
  * Transaction origin used for local writes. Must match the origin
@@ -18,6 +38,14 @@ import { type CommandSlug, type CommandStatus } from '../../shared/commands.js';
  * queued for sync.
  */
 const LOCAL_ORIGIN = 'local';
+
+/**
+ * Maximum time awaitCommandInMap() blocks waiting for sync to deliver
+ * a command. Long enough to absorb the typical browser → sync-server →
+ * MCP round-trip, short enough that a genuinely wedged sync still lets
+ * the tool call return.
+ */
+const AWAIT_COMMAND_TIMEOUT_MS = 2000;
 
 // --- Protocol version compatibility ---
 
@@ -118,9 +146,16 @@ export class CommandClient {
 			// Only process remote changes (from the browser via sync).
 			if (event.transaction.local) return;
 
-			// The 'commands' key in the document map holds all command objects.
-			if (event.changes.keys.has('commands')) {
-				debugLog('cmd-client', 'commands key changed, processing');
+			// Per-command keys (`cmd_${id}`) store individual command objects.
+			let touched = false;
+			for (const key of event.changes.keys.keys()) {
+				if (isCommandKey(key)) {
+					touched = true;
+					break;
+				}
+			}
+			if (touched) {
+				debugLog('cmd-client', 'command keys changed, processing');
 				this.processAllCommands();
 			}
 		};
@@ -165,19 +200,28 @@ export class CommandClient {
 		const map = this.commandMap;
 		if (!map) return;
 
-		// Read current commands, update the specific command, write back.
-		const raw = map.get('commands');
-		const commands = (raw as Record<string, unknown> | undefined) ?? {};
+		const key = commandKey(command.id);
+
+		// Guard against stale writes: if the Y.Doc already holds a more
+		// advanced status for this command, skip. Two REST PATCHes can be
+		// in flight simultaneously (e.g. server auto-claim → running and
+		// Claude completing the command), and the later-resolving one can
+		// otherwise overwrite the earlier-resolving one with older state.
+		const existing = map.get(key) as Command | undefined;
+		if (
+			existing &&
+			STATUS_RANK[command.status] < STATUS_RANK[existing.status]
+		) {
+			return;
+		}
 
 		const plain: Record<string, unknown> = {};
 		for (const [k, v] of Object.entries(command)) {
 			plain[k] = v;
 		}
 
-		const updated = { ...commands, [String(command.id)]: plain };
-
 		map.doc?.transact(() => {
-			map.set('commands', updated);
+			map.set(key, plain);
 		}, LOCAL_ORIGIN);
 	}
 
@@ -188,13 +232,8 @@ export class CommandClient {
 		const map = this.commandMap;
 		if (!map) return;
 
-		const raw = map.get('commands');
-		const commands = (raw as Record<string, unknown> | undefined) ?? {};
-
-		const { [String(commandId)]: _, ...remaining } = commands;
-
 		map.doc?.transact(() => {
-			map.set('commands', remaining);
+			map.delete(commandKey(commandId));
 		}, LOCAL_ORIGIN);
 	}
 
@@ -225,7 +264,15 @@ export class CommandClient {
 			}
 		);
 
-		// Mirror the updated state to the Y.Doc so the browser sees it.
+		// Wait for sync to deliver the command to the shared map before
+		// mirroring the new status. The command originates from the browser,
+		// so if writeCommandToDoc runs before that arrival our item is
+		// CRDT-concurrent with the browser's pending write and Y.Map's
+		// tiebreak can discard ours, stranding the panel at "pending". A
+		// short bounded wait is enough to serialise the writes; if sync is
+		// wedged we fall through and write anyway.
+		await this.awaitCommandInMap(id);
+
 		// Terminal commands are NOT removed here — the browser-side stale
 		// cleanup handles removal after processing. Removing on a timer
 		// risks the browser never seeing the terminal state if its polling
@@ -235,48 +282,59 @@ export class CommandClient {
 		return command;
 	}
 
+	/**
+	 * Resolve once `cmd_${id}` exists in the observed map, or after a
+	 * bounded timeout. Driven by the Y.Map observer rather than a polling
+	 * loop so there's no 50ms jitter on the happy path and no CPU burn
+	 * while waiting.
+	 */
+	private async awaitCommandInMap(id: number): Promise<void> {
+		const map = this.commandMap;
+		if (!map) return;
+		const key = commandKey(id);
+		if (map.get(key) !== undefined) return;
+
+		await new Promise<void>((resolve) => {
+			const timeout = setTimeout(() => {
+				map.unobserve(onChange);
+				resolve();
+			}, AWAIT_COMMAND_TIMEOUT_MS);
+
+			const onChange = (event: Y.YMapEvent<unknown>): void => {
+				if (!event.changes.keys.has(key)) return;
+				if (map.get(key) === undefined) return;
+				clearTimeout(timeout);
+				map.unobserve(onChange);
+				resolve();
+			};
+			map.observe(onChange);
+		});
+	}
+
 	// --- Internal ---
 
-	/**
-	 * Process all commands in the 'commands' key of the document map.
-	 */
 	private processAllCommands(): void {
-		if (!this.commandMap) return;
-
-		const raw = this.commandMap.get('commands');
-		if (isDebugEnabled()) {
-			debugLog(
-				'cmd-client',
-				'processAllCommands, raw type:',
-				typeof raw,
-				'value:',
-				raw ? JSON.stringify(raw).slice(0, 200) : 'undefined'
-			);
-		}
-
-		const commands = raw as Record<string, unknown> | undefined;
-		if (!commands || typeof commands !== 'object') {
-			debugLog('cmd-client', 'No commands object found');
-			return;
-		}
-
-		if (isDebugEnabled()) {
-			debugLog(
-				'cmd-client',
-				'Found',
-				Object.keys(commands).length,
-				'commands:',
-				Object.keys(commands)
-			);
-		}
+		const map = this.commandMap;
+		if (!map) return;
 
 		const currentIds = new Set<number>();
-		for (const value of Object.values(commands)) {
-			if (value && typeof value === 'object') {
-				const cmd = value as Command;
-				if (cmd.id) currentIds.add(cmd.id);
+		map.forEach((value, key) => {
+			if (!isCommandKey(key)) return;
+			if (!value || typeof value !== 'object') return;
+			const cmd = value as Command;
+			if (typeof cmd.id === 'number') {
+				currentIds.add(cmd.id);
 				this.processCommand(cmd);
 			}
+		});
+
+		if (isDebugEnabled()) {
+			debugLog(
+				'cmd-client',
+				'processAllCommands: found',
+				currentIds.size,
+				'commands'
+			);
 		}
 
 		// Prune tracking state for commands no longer in the Y.Map.

--- a/src/wordpress/command-client.ts
+++ b/src/wordpress/command-client.ts
@@ -11,6 +11,7 @@ import * as Y from 'yjs';
 import { debugLog, isDebugEnabled } from '../debug-log.js';
 import type { WordPressApiClient } from './api-client.js';
 import {
+	commandIdFromKey,
 	commandKey,
 	isCommandKey,
 	type CommandSlug,
@@ -297,19 +298,24 @@ export class CommandClient {
 		if (map.get(key) !== undefined) return;
 
 		await new Promise<void>((resolve) => {
-			const timeout = setTimeout(() => {
-				map.unobserve(onChange);
-				resolve();
-			}, AWAIT_COMMAND_TIMEOUT_MS);
-
-			const onChange = (event: Y.YMapEvent<unknown>): void => {
-				if (!event.changes.keys.has(key)) return;
-				if (map.get(key) === undefined) return;
+			let settled = false;
+			const finish = (): void => {
+				if (settled) return;
+				settled = true;
 				clearTimeout(timeout);
 				map.unobserve(onChange);
 				resolve();
 			};
+			const timeout = setTimeout(finish, AWAIT_COMMAND_TIMEOUT_MS);
+			const onChange = (event: Y.YMapEvent<unknown>): void => {
+				if (!event.changes.keys.has(key)) return;
+				if (map.get(key) === undefined) return;
+				finish();
+			};
 			map.observe(onChange);
+			// Re-check after observing — the key may have arrived between
+			// the earlier `map.get` check and `map.observe` registration.
+			if (map.get(key) !== undefined) finish();
 		});
 	}
 
@@ -321,13 +327,16 @@ export class CommandClient {
 
 		const currentIds = new Set<number>();
 		map.forEach((value, key) => {
-			if (!isCommandKey(key)) return;
+			const id = commandIdFromKey(key);
+			if (id === null) return;
 			if (!value || typeof value !== 'object') return;
 			const cmd = value as Command;
-			if (typeof cmd.id === 'number') {
-				currentIds.add(cmd.id);
-				this.processCommand(cmd);
-			}
+			// Skip entries whose stored `id` doesn't match the key suffix —
+			// they can't be processed or pruned consistently, so treat
+			// them as corrupt and ignore.
+			if (cmd.id !== id) return;
+			currentIds.add(id);
+			this.processCommand(cmd);
 		});
 
 		if (isDebugEnabled()) {

--- a/tests/e2e/pre-publish-panel.spec.ts
+++ b/tests/e2e/pre-publish-panel.spec.ts
@@ -218,19 +218,17 @@ test.describe('Pre-Publish Panel', () => {
 			resultData: JSON.stringify(resultData),
 		});
 
-		// Wait for suggestions to appear in the browser
-		await expect
-			.poll(
-				async () =>
-					page
-						.getByText(
-							'A test post for pre-publish checks with AI-suggested metadata.'
-						)
-						.isVisible()
-						.catch(() => false),
-				{ timeout: 30_000, intervals: [1000] }
-			)
-			.toBe(true);
+		// Wait for the excerpt suggestion to render. The TextareaControl is
+		// a React-controlled <textarea>: React updates the `value` DOM
+		// property on re-render but not the element's text content, so
+		// `getByText` cannot match the excerpt. Assert against the textarea
+		// value instead.
+		await expect(
+			page.locator('.wpce-pre-publish-panel__excerpt-textarea textarea')
+		).toHaveValue(
+			'A test post for pre-publish checks with AI-suggested metadata.',
+			{ timeout: 30_000 }
+		);
 
 		// Verify category and tag term chips are displayed
 		const termsContainers = page.locator('.wpce-pre-publish-panel__terms');

--- a/tests/unit/command-client.test.ts
+++ b/tests/unit/command-client.test.ts
@@ -213,26 +213,31 @@ describe('CommandClient', () => {
 		});
 
 		it('does not schedule removal for non-terminal statuses', async () => {
-			const { localDoc } = createSyncedDocs();
-			const documentMap = localDoc.getMap('document');
-			client.startObserving(documentMap);
-			seedPending(documentMap, 8);
-
-			const running = fakeCommand({ id: 8, status: 'running' });
-			apiClient.request.mockResolvedValue(running);
-
-			await client.updateCommandStatus(8, 'running');
-
 			vi.useFakeTimers();
+			try {
+				const { localDoc } = createSyncedDocs();
+				const documentMap = localDoc.getMap('document');
+				client.startObserving(documentMap);
+				seedPending(documentMap, 8);
 
-			expect(documentMap.get('cmd_8')).toBeDefined();
+				const running = fakeCommand({ id: 8, status: 'running' });
+				apiClient.request.mockResolvedValue(running);
 
-			// Even after 5s, it should still be there
-			vi.advanceTimersByTime(5000);
+				// Flush microtasks so the awaited PATCH resolves under
+				// fake timers; updateCommandStatus short-circuits its
+				// awaitCommandInMap because cmd_8 is already seeded.
+				await vi.advanceTimersByTimeAsync(0);
+				await client.updateCommandStatus(8, 'running');
 
-			expect(documentMap.get('cmd_8')).toBeDefined();
+				expect(documentMap.get('cmd_8')).toBeDefined();
 
-			vi.useRealTimers();
+				// Even after 5 s, nothing should have scheduled the entry
+				// for removal.
+				await vi.advanceTimersByTimeAsync(5000);
+				expect(documentMap.get('cmd_8')).toBeDefined();
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('keeps failed commands in Y.Map for browser-side cleanup', async () => {

--- a/tests/unit/command-client.test.ts
+++ b/tests/unit/command-client.test.ts
@@ -541,6 +541,21 @@ describe('CommandClient', () => {
 
 			expect(onCommand).not.toHaveBeenCalled();
 		});
+
+		it('skips entries whose stored id does not match the key suffix', () => {
+			const { remoteDoc, localDoc, syncToLocal } = createSyncedDocs();
+			const documentMap = localDoc.getMap('document');
+			client.startObserving(documentMap);
+
+			// Mismatched entry: stored under cmd_70 but carries id 71.
+			// Can't be looked up or removed consistently, so it must be
+			// ignored rather than dispatched under id 71.
+			const remoteMap = remoteDoc.getMap('document');
+			remoteMap.set('cmd_70', fakeCommand({ id: 71, status: 'pending' }));
+			syncToLocal();
+
+			expect(onCommand).not.toHaveBeenCalled();
+		});
 	});
 
 	// -------------------------------------------------------

--- a/tests/unit/command-client.test.ts
+++ b/tests/unit/command-client.test.ts
@@ -37,6 +37,14 @@ function fakeCommand(overrides?: Partial<Command>): Command {
 }
 
 /**
+ * Seed a pending command into the observed map so updateCommandStatus()
+ * finds it immediately and skips the sync-delivery wait.
+ */
+function seedPending(map: Y.Map<unknown>, id: number): void {
+	map.set(`cmd_${id}`, fakeCommand({ id, status: 'pending' }));
+}
+
+/**
  * Creates a pair of Y.Docs that simulate remote/local sync.
  * Changes on `remoteDoc` can be synced to `localDoc` via `syncToLocal()`.
  */
@@ -188,6 +196,7 @@ describe('CommandClient', () => {
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
+			seedPending(documentMap, 7);
 
 			const completed = fakeCommand({ id: 7, status: 'completed' });
 			apiClient.request.mockResolvedValue(completed);
@@ -196,40 +205,32 @@ describe('CommandClient', () => {
 
 			// Terminal command should persist in the Y.Map (browser-side
 			// stale cleanup handles removal after processing).
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['7']).toBeDefined();
-			expect((commands['7'] as { status: string }).status).toBe(
-				'completed'
-			);
+			const entry = documentMap.get('cmd_7') as
+				| { status: string }
+				| undefined;
+			expect(entry).toBeDefined();
+			expect(entry?.status).toBe('completed');
 		});
 
 		it('does not schedule removal for non-terminal statuses', async () => {
-			vi.useFakeTimers();
-
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
+			seedPending(documentMap, 8);
 
 			const running = fakeCommand({ id: 8, status: 'running' });
 			apiClient.request.mockResolvedValue(running);
 
 			await client.updateCommandStatus(8, 'running');
 
-			// Command should be in the Y.Map
-			let commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['8']).toBeDefined();
+			vi.useFakeTimers();
+
+			expect(documentMap.get('cmd_8')).toBeDefined();
 
 			// Even after 5s, it should still be there
 			vi.advanceTimersByTime(5000);
 
-			commands = documentMap.get('commands') as Record<string, unknown>;
-			expect(commands['8']).toBeDefined();
+			expect(documentMap.get('cmd_8')).toBeDefined();
 
 			vi.useRealTimers();
 		});
@@ -238,39 +239,36 @@ describe('CommandClient', () => {
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
+			seedPending(documentMap, 9);
 
 			const failed = fakeCommand({ id: 9, status: 'failed' });
 			apiClient.request.mockResolvedValue(failed);
 
 			await client.updateCommandStatus(9, 'failed', 'Something broke');
 
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['9']).toBeDefined();
-			expect((commands['9'] as { status: string }).status).toBe('failed');
+			const entry = documentMap.get('cmd_9') as
+				| { status: string }
+				| undefined;
+			expect(entry).toBeDefined();
+			expect(entry?.status).toBe('failed');
 		});
 
 		it('writes the updated command to the Y.Map', async () => {
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
+			seedPending(documentMap, 3);
 
 			const updated = fakeCommand({ id: 3, status: 'running' });
 			apiClient.request.mockResolvedValue(updated);
 
 			await client.updateCommandStatus(3, 'running');
 
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands).toBeDefined();
-			expect(commands['3']).toBeDefined();
-			expect((commands['3'] as Record<string, unknown>).status).toBe(
-				'running'
-			);
+			const entry = documentMap.get('cmd_3') as
+				| Record<string, unknown>
+				| undefined;
+			expect(entry).toBeDefined();
+			expect(entry?.status).toBe('running');
 		});
 
 		it('does not write to Y.Map when not observing', async () => {
@@ -305,9 +303,7 @@ describe('CommandClient', () => {
 
 			// Write a pending command to the remote doc before observing
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'10': fakeCommand({ id: 10, status: 'pending' }),
-			});
+			remoteMap.set('cmd_10', fakeCommand({ id: 10, status: 'pending' }));
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -345,9 +341,7 @@ describe('CommandClient', () => {
 
 			// Write a command after stop
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'20': fakeCommand({ id: 20, status: 'pending' }),
-			});
+			remoteMap.set('cmd_20', fakeCommand({ id: 20, status: 'pending' }));
 			syncToLocal();
 
 			expect(onCommand).not.toHaveBeenCalled();
@@ -359,9 +353,7 @@ describe('CommandClient', () => {
 
 			// Write a command and observe
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'30': fakeCommand({ id: 30, status: 'pending' }),
-			});
+			remoteMap.set('cmd_30', fakeCommand({ id: 30, status: 'pending' }));
 			syncToLocal();
 
 			client.startObserving(documentMap);
@@ -404,13 +396,14 @@ describe('CommandClient', () => {
 
 			// Remote browser writes a pending command
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'50': fakeCommand({
+			remoteMap.set(
+				'cmd_50',
+				fakeCommand({
 					id: 50,
 					status: 'pending',
 					prompt: 'review',
-				}),
-			});
+				})
+			);
 			syncToLocal();
 
 			expect(onCommand).toHaveBeenCalledOnce();
@@ -429,10 +422,8 @@ describe('CommandClient', () => {
 			client.startObserving(documentMap);
 
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'51': fakeCommand({ id: 51, status: 'pending' }),
-				'52': fakeCommand({ id: 52, status: 'pending' }),
-			});
+			remoteMap.set('cmd_51', fakeCommand({ id: 51, status: 'pending' }));
+			remoteMap.set('cmd_52', fakeCommand({ id: 52, status: 'pending' }));
 			syncToLocal();
 
 			expect(onCommand).toHaveBeenCalledTimes(2);
@@ -444,9 +435,7 @@ describe('CommandClient', () => {
 			client.startObserving(documentMap);
 
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'60': fakeCommand({ id: 60, status: 'running' }),
-			});
+			remoteMap.set('cmd_60', fakeCommand({ id: 60, status: 'running' }));
 			syncToLocal();
 
 			expect(onCommand).not.toHaveBeenCalled();
@@ -458,9 +447,10 @@ describe('CommandClient', () => {
 			client.startObserving(documentMap);
 
 			// Local write (e.g., status update written by MCP server)
-			documentMap.set('commands', {
-				'70': fakeCommand({ id: 70, status: 'pending' }),
-			});
+			documentMap.set(
+				'cmd_70',
+				fakeCommand({ id: 70, status: 'pending' })
+			);
 
 			// The initial processAllCommands in startObserving would
 			// have seen the empty map, so onCommand should only be
@@ -480,8 +470,9 @@ describe('CommandClient', () => {
 			client.startObserving(documentMap);
 
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				bad: { status: 'pending', prompt: 'proofread' },
+			remoteMap.set('cmd_bad', {
+				status: 'pending',
+				prompt: 'proofread',
 			});
 			syncToLocal();
 
@@ -503,14 +494,14 @@ describe('CommandClient', () => {
 			const cmd = fakeCommand({ id: 80, status: 'pending' });
 
 			// First sync
-			remoteMap.set('commands', { '80': cmd });
+			remoteMap.set('cmd_80', cmd);
 			syncToLocal();
 			expect(onCommand).toHaveBeenCalledOnce();
 
 			onCommand.mockClear();
 
 			// Second sync with same command (e.g., another field in the map changes)
-			remoteMap.set('commands', { '80': cmd });
+			remoteMap.set('cmd_80', { ...cmd });
 			syncToLocal();
 			expect(onCommand).not.toHaveBeenCalled();
 		});
@@ -520,9 +511,7 @@ describe('CommandClient', () => {
 
 			// Pre-populate
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'81': fakeCommand({ id: 81, status: 'pending' }),
-			});
+			remoteMap.set('cmd_81', fakeCommand({ id: 81, status: 'pending' }));
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -531,9 +520,7 @@ describe('CommandClient', () => {
 			onCommand.mockClear();
 
 			// Sync again with same data — should not re-notify
-			remoteMap.set('commands', {
-				'81': fakeCommand({ id: 81, status: 'pending' }),
-			});
+			remoteMap.set('cmd_81', fakeCommand({ id: 81, status: 'pending' }));
 			syncToLocal();
 			expect(onCommand).not.toHaveBeenCalled();
 		});
@@ -552,22 +539,18 @@ describe('CommandClient', () => {
 			const remoteMap = remoteDoc.getMap('document');
 
 			// Add a pending command — it gets tracked in notifiedPendingIds.
-			remoteMap.set('commands', {
-				'90': fakeCommand({ id: 90, status: 'pending' }),
-			});
+			remoteMap.set('cmd_90', fakeCommand({ id: 90, status: 'pending' }));
 			syncToLocal();
 			expect(onCommand).toHaveBeenCalledOnce();
 			onCommand.mockClear();
 
 			// Remove the command from the Y.Map (simulates terminal cleanup).
-			remoteMap.set('commands', {});
+			remoteMap.delete('cmd_90');
 			syncToLocal();
 
 			// Re-add the same command — should be notified again because
 			// the pruning cleared the tracked ID.
-			remoteMap.set('commands', {
-				'90': fakeCommand({ id: 90, status: 'pending' }),
-			});
+			remoteMap.set('cmd_90', fakeCommand({ id: 90, status: 'pending' }));
 			syncToLocal();
 			expect(onCommand).toHaveBeenCalledOnce();
 		});
@@ -590,18 +573,18 @@ describe('CommandClient', () => {
 					],
 				},
 			});
-			remoteMap.set('commands', { '91': cmd });
+			remoteMap.set('cmd_91', cmd);
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 			onResponse.mockClear();
 
 			// Remove the command.
-			remoteMap.set('commands', {});
+			remoteMap.delete('cmd_91');
 			syncToLocal();
 
 			// Re-add with same message count — should trigger onResponse
 			// again because the pruning cleared the tracked count.
-			remoteMap.set('commands', { '91': cmd });
+			remoteMap.set('cmd_91', { ...cmd });
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 		});
@@ -617,8 +600,9 @@ describe('CommandClient', () => {
 
 			// Pre-populate a running command with user messages BEFORE observing
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'200': fakeCommand({
+			remoteMap.set(
+				'cmd_200',
+				fakeCommand({
 					id: 200,
 					status: 'running',
 					result_data: {
@@ -627,8 +611,8 @@ describe('CommandClient', () => {
 							{ role: 'assistant', content: 'Working on it' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -643,8 +627,9 @@ describe('CommandClient', () => {
 
 			// Pre-populate a running command with one user message
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'201': fakeCommand({
+			remoteMap.set(
+				'cmd_201',
+				fakeCommand({
 					id: 201,
 					status: 'running',
 					result_data: {
@@ -653,8 +638,8 @@ describe('CommandClient', () => {
 							{ role: 'assistant', content: 'Got it' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -662,8 +647,9 @@ describe('CommandClient', () => {
 			expect(onResponse).not.toHaveBeenCalled();
 
 			// Now a NEW user message arrives via remote sync
-			remoteMap.set('commands', {
-				'201': fakeCommand({
+			remoteMap.set(
+				'cmd_201',
+				fakeCommand({
 					id: 201,
 					status: 'running',
 					result_data: {
@@ -673,8 +659,8 @@ describe('CommandClient', () => {
 							{ role: 'user', content: 'Second message' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 
 			expect(onResponse).toHaveBeenCalledOnce();
@@ -688,15 +674,19 @@ describe('CommandClient', () => {
 
 			// Pre-populate multiple running commands with messages
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'202': fakeCommand({
+			remoteMap.set(
+				'cmd_202',
+				fakeCommand({
 					id: 202,
 					status: 'running',
 					result_data: {
 						messages: [{ role: 'user', content: 'Message A' }],
 					},
-				}),
-				'203': fakeCommand({
+				})
+			);
+			remoteMap.set(
+				'cmd_203',
+				fakeCommand({
 					id: 203,
 					status: 'running',
 					result_data: {
@@ -705,8 +695,8 @@ describe('CommandClient', () => {
 							{ role: 'user', content: 'Message C' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -730,8 +720,9 @@ describe('CommandClient', () => {
 			const remoteMap = remoteDoc.getMap('document');
 
 			// First: command arrives as running (claimed by MCP)
-			remoteMap.set('commands', {
-				'90': fakeCommand({
+			remoteMap.set(
+				'cmd_90',
+				fakeCommand({
 					id: 90,
 					status: 'running',
 					result_data: {
@@ -739,14 +730,15 @@ describe('CommandClient', () => {
 							{ role: 'assistant', content: 'Working on it...' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).not.toHaveBeenCalled();
 
 			// User sends a message
-			remoteMap.set('commands', {
-				'90': fakeCommand({
+			remoteMap.set(
+				'cmd_90',
+				fakeCommand({
 					id: 90,
 					status: 'running',
 					result_data: {
@@ -758,8 +750,8 @@ describe('CommandClient', () => {
 							},
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 			expect(onResponse).toHaveBeenCalledWith(
@@ -777,8 +769,9 @@ describe('CommandClient', () => {
 
 			const remoteMap = remoteDoc.getMap('document');
 
-			const cmdData = {
-				'91': fakeCommand({
+			remoteMap.set(
+				'cmd_91',
+				fakeCommand({
 					id: 91,
 					status: 'running',
 					result_data: {
@@ -787,17 +780,16 @@ describe('CommandClient', () => {
 							{ role: 'assistant', content: 'Done.' },
 						],
 					},
-				}),
-			};
-
-			remoteMap.set('commands', cmdData);
+				})
+			);
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 			onResponse.mockClear();
 
 			// Sync again with same message count — no new notification
-			remoteMap.set('commands', {
-				'91': fakeCommand({
+			remoteMap.set(
+				'cmd_91',
+				fakeCommand({
 					id: 91,
 					status: 'running',
 					result_data: {
@@ -806,8 +798,8 @@ describe('CommandClient', () => {
 							{ role: 'assistant', content: 'Done, updated.' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).not.toHaveBeenCalled();
 		});
@@ -820,15 +812,16 @@ describe('CommandClient', () => {
 			const remoteMap = remoteDoc.getMap('document');
 
 			// Completed command with messages — should not trigger response
-			remoteMap.set('commands', {
-				'92': fakeCommand({
+			remoteMap.set(
+				'cmd_92',
+				fakeCommand({
 					id: 92,
 					status: 'completed',
 					result_data: {
 						messages: [{ role: 'user', content: 'Thanks' }],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).not.toHaveBeenCalled();
 		});
@@ -840,13 +833,14 @@ describe('CommandClient', () => {
 
 			const remoteMap = remoteDoc.getMap('document');
 
-			remoteMap.set('commands', {
-				'93': fakeCommand({
+			remoteMap.set(
+				'cmd_93',
+				fakeCommand({
 					id: 93,
 					status: 'running',
 					result_data: { some_other_field: true },
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).not.toHaveBeenCalled();
 		});
@@ -859,22 +853,24 @@ describe('CommandClient', () => {
 			const remoteMap = remoteDoc.getMap('document');
 
 			// First user message
-			remoteMap.set('commands', {
-				'94': fakeCommand({
+			remoteMap.set(
+				'cmd_94',
+				fakeCommand({
 					id: 94,
 					status: 'running',
 					result_data: {
 						messages: [{ role: 'user', content: 'First question' }],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 			onResponse.mockClear();
 
 			// Second user message
-			remoteMap.set('commands', {
-				'94': fakeCommand({
+			remoteMap.set(
+				'cmd_94',
+				fakeCommand({
 					id: 94,
 					status: 'running',
 					result_data: {
@@ -884,8 +880,8 @@ describe('CommandClient', () => {
 							{ role: 'user', content: 'Follow-up question' },
 						],
 					},
-				}),
-			});
+				})
+			);
 			syncToLocal();
 			expect(onResponse).toHaveBeenCalledOnce();
 		});
@@ -896,7 +892,7 @@ describe('CommandClient', () => {
 	// -------------------------------------------------------
 
 	describe('writeCommandToDoc()', () => {
-		it('sets the command under the commands key in the Y.Map', () => {
+		it('sets the command under its dedicated key in the Y.Map', () => {
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
@@ -904,14 +900,10 @@ describe('CommandClient', () => {
 			const cmd = fakeCommand({ id: 100, status: 'running' });
 			client.writeCommandToDoc(cmd);
 
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands).toBeDefined();
-			expect(commands['100']).toBeDefined();
-			expect((commands['100'] as Command).id).toBe(100);
-			expect((commands['100'] as Command).status).toBe('running');
+			const entry = documentMap.get('cmd_100') as Command | undefined;
+			expect(entry).toBeDefined();
+			expect(entry?.id).toBe(100);
+			expect(entry?.status).toBe('running');
 		});
 
 		it('uses LOCAL_ORIGIN so updates are queued for sync', () => {
@@ -943,12 +935,8 @@ describe('CommandClient', () => {
 				fakeCommand({ id: 102, status: 'running' })
 			);
 
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['101']).toBeDefined();
-			expect(commands['102']).toBeDefined();
+			expect(documentMap.get('cmd_101')).toBeDefined();
+			expect(documentMap.get('cmd_102')).toBeDefined();
 		});
 
 		it('is a no-op when not observing', () => {
@@ -964,7 +952,7 @@ describe('CommandClient', () => {
 	// -------------------------------------------------------
 
 	describe('removeCommandFromDoc()', () => {
-		it('removes a command from the commands key in the Y.Map', () => {
+		it('removes a command entry from the Y.Map', () => {
 			const { localDoc } = createSyncedDocs();
 			const documentMap = localDoc.getMap('document');
 			client.startObserving(documentMap);
@@ -978,12 +966,8 @@ describe('CommandClient', () => {
 
 			client.removeCommandFromDoc(110);
 
-			const commands = documentMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['110']).toBeUndefined();
-			expect(commands['111']).toBeDefined();
+			expect(documentMap.get('cmd_110')).toBeUndefined();
+			expect(documentMap.get('cmd_111')).toBeDefined();
 		});
 
 		it('uses LOCAL_ORIGIN so updates are queued for sync', () => {
@@ -1091,9 +1075,10 @@ describe('CommandClient', () => {
 			debugSpy.mockClear();
 
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'300': fakeCommand({ id: 300, status: 'pending' }),
-			});
+			remoteMap.set(
+				'cmd_300',
+				fakeCommand({ id: 300, status: 'pending' })
+			);
 			syncToLocal();
 
 			expect(debugSpy).toHaveBeenCalledWith(
@@ -1108,9 +1093,10 @@ describe('CommandClient', () => {
 		it('logs processAllCommands details when debug is enabled', () => {
 			const { remoteDoc, localDoc, syncToLocal } = createSyncedDocs();
 			const remoteMap = remoteDoc.getMap('document');
-			remoteMap.set('commands', {
-				'301': fakeCommand({ id: 301, status: 'pending' }),
-			});
+			remoteMap.set(
+				'cmd_301',
+				fakeCommand({ id: 301, status: 'pending' })
+			);
 			syncToLocal();
 
 			const documentMap = localDoc.getMap('document');
@@ -1118,17 +1104,9 @@ describe('CommandClient', () => {
 
 			expect(debugSpy).toHaveBeenCalledWith(
 				'cmd-client',
-				'processAllCommands, raw type:',
-				'object',
-				'value:',
-				expect.any(String)
-			);
-			expect(debugSpy).toHaveBeenCalledWith(
-				'cmd-client',
-				'Found',
+				'processAllCommands: found',
 				1,
-				'commands:',
-				['301']
+				'commands'
 			);
 		});
 	});

--- a/tests/unit/command-client.test.ts
+++ b/tests/unit/command-client.test.ts
@@ -280,6 +280,64 @@ describe('CommandClient', () => {
 			const result = await client.updateCommandStatus(3, 'running');
 			expect(result).toEqual(updated);
 		});
+
+		it('waits for the browser-origin pending write to arrive before mirroring', async () => {
+			// Simulates the ordering the observer-backed wait is meant to
+			// enforce: the REST PATCH resolves before sync has delivered
+			// the browser's pending write, and the mirror must hold off
+			// until the pending entry appears in the Y.Map.
+			const { remoteDoc, localDoc, syncToLocal } = createSyncedDocs();
+			const documentMap = localDoc.getMap('document');
+			client.startObserving(documentMap);
+
+			const running = fakeCommand({ id: 11, status: 'running' });
+			apiClient.request.mockResolvedValue(running);
+
+			const inFlight = client.updateCommandStatus(11, 'running');
+
+			// Y.Map is empty, so the mirror is stalled on awaitCommandInMap.
+			await Promise.resolve();
+			expect(documentMap.get('cmd_11')).toBeUndefined();
+
+			// Deliver the browser's pending write; the observer should
+			// unblock the wait and let the mirror complete.
+			const remoteMap = remoteDoc.getMap('document');
+			remoteMap.set('cmd_11', fakeCommand({ id: 11, status: 'pending' }));
+			syncToLocal();
+
+			await inFlight;
+
+			const entry = documentMap.get('cmd_11') as Command | undefined;
+			expect(entry?.status).toBe('running');
+		});
+
+		it('mirrors after the wait timeout when sync never delivers', async () => {
+			vi.useFakeTimers();
+			try {
+				const { localDoc } = createSyncedDocs();
+				const documentMap = localDoc.getMap('document');
+				client.startObserving(documentMap);
+
+				const failed = fakeCommand({ id: 12, status: 'failed' });
+				apiClient.request.mockResolvedValue(failed);
+
+				const inFlight = client.updateCommandStatus(12, 'failed');
+
+				// Give the REST request time to resolve so the code is
+				// parked inside awaitCommandInMap.
+				await vi.advanceTimersByTimeAsync(0);
+				expect(documentMap.get('cmd_12')).toBeUndefined();
+
+				// Advance past the 2 s timeout; the mirror should fall
+				// through and write anyway.
+				await vi.advanceTimersByTimeAsync(2000);
+				await inFlight;
+
+				expect(documentMap.get('cmd_12')).toBeDefined();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	// -------------------------------------------------------
@@ -937,6 +995,30 @@ describe('CommandClient', () => {
 
 			expect(documentMap.get('cmd_101')).toBeDefined();
 			expect(documentMap.get('cmd_102')).toBeDefined();
+		});
+
+		it('skips writes that would downgrade a terminal status', () => {
+			// Guards against a late-arriving stale REST response (e.g.
+			// the server's auto-claim → running resolving after the
+			// caller's → completed) clobbering the fresh terminal state.
+			const { localDoc } = createSyncedDocs();
+			const documentMap = localDoc.getMap('document');
+			client.startObserving(documentMap);
+
+			client.writeCommandToDoc(
+				fakeCommand({
+					id: 105,
+					status: 'completed',
+					message: 'All done',
+				})
+			);
+			client.writeCommandToDoc(
+				fakeCommand({ id: 105, status: 'running' })
+			);
+
+			const entry = documentMap.get('cmd_105') as Command | undefined;
+			expect(entry?.status).toBe('completed');
+			expect(entry?.message).toBe('All done');
 		});
 
 		it('is a no-op when not observing', () => {

--- a/wordpress-plugin/src/sync/command-sync.ts
+++ b/wordpress-plugin/src/sync/command-sync.ts
@@ -23,7 +23,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Y, Awareness } from '@wordpress/sync';
 // eslint-disable-next-line import/no-extraneous-dependencies -- externalized by @wordpress/scripts
 import { addFilter } from '@wordpress/hooks';
-import { TERMINAL_STATUSES } from '#shared/commands';
+import { TERMINAL_STATUSES, commandKey, isCommandKey } from '#shared/commands';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
@@ -287,10 +287,8 @@ async function startStaleCommandCleanup(): Promise<void> {
 		const stateMap = getStateMap();
 		if (!stateMap) return;
 
-		const commands = stateMap.get('commands') as
-			| Record<string, unknown>
-			| undefined;
-		if (!commands || Object.keys(commands).length === 0) return;
+		const current = collectCommandsFromStateMap(stateMap);
+		if (Object.keys(current).length === 0) return;
 
 		try {
 			// Per-user room: all commands belong to the current user,
@@ -304,19 +302,25 @@ async function startStaleCommandCleanup(): Promise<void> {
 					.map((c) => String(c.id))
 			);
 
-			const cleaned: Record<string, unknown> = {};
-			let changed = false;
-			for (const [id, value] of Object.entries(commands)) {
-				if (activeIds.has(id)) {
-					cleaned[id] = value;
-				} else {
-					changed = true;
+			const toRemove: string[] = [];
+			for (const [id, cmd] of Object.entries(current)) {
+				if (activeIds.has(id)) continue;
+				// Only remove commands that have already reached a terminal
+				// state in the local Y.Doc. If REST reports terminal but the
+				// Y.Doc still holds a non-terminal status, the terminal
+				// update is in flight from the MCP server — removing it now
+				// would drop the transition before handleSyncUpdate can
+				// dispatch CLEAR_ACTIVE_COMMAND.
+				if (cmd && TERMINAL_STATUSES.includes(cmd.status)) {
+					toRemove.push(id);
 				}
 			}
 
-			if (changed) {
+			if (toRemove.length > 0) {
 				commandDoc?.transact(() => {
-					stateMap.set('commands', cleaned);
+					for (const id of toRemove) {
+						stateMap.delete(commandKey(id));
+					}
 					stateMap.set('savedAt', Date.now());
 				});
 				commandDocDirty = true;
@@ -357,24 +361,21 @@ function flushPendingWrites(): boolean {
 }
 
 /**
- * Apply a single command write to the state map.
+ * Apply a single command write to the state map. Writes to a dedicated
+ * `cmd_${id}` key so the write only affects that command's item — no
+ * chance of clobbering concurrent updates for other commands, and
+ * same-command writes from the MCP stay causally ordered.
  * @param stateMap
  * @param command
  */
 function applyCommandToStateMap(stateMap: YMap, command: Command): void {
-	const commands = {
-		...((stateMap.get('commands') as Record<string, unknown> | undefined) ??
-			{}),
-	};
-
-	if (TERMINAL_STATUSES.includes(command.status)) {
-		delete commands[String(command.id)];
-	} else {
-		commands[String(command.id)] = { ...command };
-	}
-
+	const key = commandKey(command.id);
 	commandDoc?.transact(() => {
-		stateMap.set('commands', commands);
+		if (TERMINAL_STATUSES.includes(command.status)) {
+			stateMap.delete(key);
+		} else {
+			stateMap.set(key, { ...command });
+		}
 		stateMap.set('savedAt', Date.now());
 	});
 
@@ -429,19 +430,31 @@ export function removeCommandFromSync(commandId: number): void {
 	const stateMap = getStateMap();
 	if (!stateMap) return;
 
-	const commands = {
-		...((stateMap.get('commands') as Record<string, unknown> | undefined) ??
-			{}),
-	};
-
-	delete commands[String(commandId)];
-
 	commandDoc?.transact(() => {
-		stateMap.set('commands', commands);
+		stateMap.delete(commandKey(commandId));
 		stateMap.set('savedAt', Date.now());
 	});
 
 	commandDocDirty = true;
+}
+
+/**
+ * Collect all commands stored as `cmd_${id}` entries in the state map.
+ * Returns an ID-keyed record so callers can keep the previous shape.
+ *
+ * @param stateMap The state Y.Map to read from.
+ */
+function collectCommandsFromStateMap(stateMap: YMap): Record<string, Command> {
+	const result: Record<string, Command> = {};
+	stateMap.forEach((value, key) => {
+		if (!isCommandKey(key)) return;
+		if (!value || typeof value !== 'object') return;
+		const cmd = value as Command;
+		if (typeof cmd.id === 'number') {
+			result[String(cmd.id)] = cmd;
+		}
+	});
+	return result;
 }
 
 /**
@@ -450,8 +463,7 @@ export function removeCommandFromSync(commandId: number): void {
 export function getCommandsFromSync(): Record<string, Command> {
 	const stateMap = getStateMap();
 	if (!stateMap) return {};
-
-	return (stateMap.get('commands') as Record<string, Command>) ?? {};
+	return collectCommandsFromStateMap(stateMap);
 }
 
 /**
@@ -485,10 +497,15 @@ export function subscribeToCommandSync(
 		observedMap = stateMap;
 
 		observer = (event: YMapEvent) => {
-			if (!event.changes.keys.has('commands')) return;
-			callback(
-				(stateMap.get('commands') as Record<string, Command>) ?? {}
-			);
+			let touched = false;
+			for (const key of event.changes.keys.keys()) {
+				if (isCommandKey(key)) {
+					touched = true;
+					break;
+				}
+			}
+			if (!touched) return;
+			callback(collectCommandsFromStateMap(stateMap));
 		};
 
 		stateMap.observe(observer);

--- a/wordpress-plugin/src/sync/command-sync.ts
+++ b/wordpress-plugin/src/sync/command-sync.ts
@@ -23,7 +23,12 @@ import apiFetch from '@wordpress/api-fetch';
 import { Y, Awareness } from '@wordpress/sync';
 // eslint-disable-next-line import/no-extraneous-dependencies -- externalized by @wordpress/scripts
 import { addFilter } from '@wordpress/hooks';
-import { TERMINAL_STATUSES, commandKey, isCommandKey } from '#shared/commands';
+import {
+	TERMINAL_STATUSES,
+	commandIdFromKey,
+	commandKey,
+	isCommandKey,
+} from '#shared/commands';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
@@ -447,12 +452,15 @@ export function removeCommandFromSync(commandId: number): void {
 function collectCommandsFromStateMap(stateMap: YMap): Record<string, Command> {
 	const result: Record<string, Command> = {};
 	stateMap.forEach((value, key) => {
-		if (!isCommandKey(key)) return;
+		const id = commandIdFromKey(key);
+		if (id === null) return;
 		if (!value || typeof value !== 'object') return;
 		const cmd = value as Command;
-		if (typeof cmd.id === 'number') {
-			result[String(cmd.id)] = cmd;
-		}
+		// Drop entries whose stored `id` doesn't match the key suffix;
+		// they can't be looked up or removed consistently so treat them
+		// as corrupt.
+		if (cmd.id !== id) return;
+		result[String(id)] = cmd;
 	});
 	return result;
 }

--- a/wordpress-plugin/src/sync/test/command-sync.test.ts
+++ b/wordpress-plugin/src/sync/test/command-sync.test.ts
@@ -10,18 +10,18 @@
 // Mock state — shared between the mock implementations and the test body.
 // ---------------------------------------------------------------------------
 
-/** Simulated Y.Map backed by a plain object. */
+/** Simulated Y.Map backed by a Map (matches Y.Map's own-key semantics). */
 class MockYMap {
-	private data: Record<string, unknown> = {};
+	private data = new Map<string, unknown>();
 	private observers: Array<(event: unknown) => void> = [];
 
 	get(key: string): unknown {
-		return this.data[key];
+		return this.data.get(key);
 	}
 
 	set(key: string, value: unknown): void {
-		const action = key in this.data ? 'update' : 'add';
-		this.data[key] = value;
+		const action = this.data.has(key) ? 'update' : 'add';
+		this.data.set(key, value);
 		const event = {
 			changes: { keys: new Map([[key, { action }]]) },
 		};
@@ -31,8 +31,8 @@ class MockYMap {
 	}
 
 	delete(key: string): void {
-		if (!(key in this.data)) return;
-		delete this.data[key];
+		if (!this.data.has(key)) return;
+		this.data.delete(key);
 		const event = {
 			changes: { keys: new Map([[key, { action: 'delete' }]]) },
 		};
@@ -42,9 +42,7 @@ class MockYMap {
 	}
 
 	forEach(callback: (value: unknown, key: string) => void): void {
-		for (const [key, value] of Object.entries(this.data)) {
-			callback(value, key);
-		}
+		this.data.forEach((value, key) => callback(value, key));
 	}
 
 	observe(fn: (event: unknown) => void): void {
@@ -461,6 +459,24 @@ describe('command-sync', () => {
 			const mod = loadModule();
 			const commands = mod.getCommandsFromSync();
 			expect(commands).toEqual({});
+		});
+
+		it('drops entries whose stored id does not match the key suffix', async () => {
+			const mod = loadModule();
+			await mod.initCommandSync();
+
+			const syncConfig = mockAddEntities.mock.calls[0][0][0].syncConfig;
+			const doc = new MockYDoc();
+			syncConfig.createAwareness(doc);
+
+			// Good entry — key and stored id agree.
+			doc.getMap('state').set('cmd_42', { ...MOCK_COMMAND, id: 42 });
+			// Corrupt entry — stored under cmd_43 but carries id 99. Must
+			// not appear under either 43 or 99 in the collected record.
+			doc.getMap('state').set('cmd_43', { ...MOCK_COMMAND, id: 99 });
+
+			const commands = mod.getCommandsFromSync();
+			expect(commands).toEqual({ '42': { ...MOCK_COMMAND, id: 42 } });
 		});
 	});
 

--- a/wordpress-plugin/src/sync/test/command-sync.test.ts
+++ b/wordpress-plugin/src/sync/test/command-sync.test.ts
@@ -20,13 +20,30 @@ class MockYMap {
 	}
 
 	set(key: string, value: unknown): void {
+		const action = key in this.data ? 'update' : 'add';
 		this.data[key] = value;
-		// Notify observers with a mock YMapEvent containing the changed key.
 		const event = {
-			changes: { keys: new Map([[key, { action: 'update' }]]) },
+			changes: { keys: new Map([[key, { action }]]) },
 		};
 		for (const fn of this.observers) {
 			fn(event);
+		}
+	}
+
+	delete(key: string): void {
+		if (!(key in this.data)) return;
+		delete this.data[key];
+		const event = {
+			changes: { keys: new Map([[key, { action: 'delete' }]]) },
+		};
+		for (const fn of this.observers) {
+			fn(event);
+		}
+	}
+
+	forEach(callback: (value: unknown, key: string) => void): void {
+		for (const [key, value] of Object.entries(this.data)) {
+			callback(value, key);
 		}
 	}
 
@@ -296,8 +313,8 @@ describe('command-sync', () => {
 			expect(typeof awareness.on).toBe('function');
 
 			// After createAwareness, the doc should be captured and commands readable.
-			doc.getMap('state').set('commands', { '1': MOCK_COMMAND });
-			expect(mod.getCommandsFromSync()['1']).toEqual(MOCK_COMMAND);
+			doc.getMap('state').set('cmd_42', MOCK_COMMAND);
+			expect(mod.getCommandsFromSync()['42']).toEqual(MOCK_COMMAND);
 		});
 	});
 
@@ -314,11 +331,9 @@ describe('command-sync', () => {
 			mod.writeCommandToSync(MOCK_COMMAND);
 
 			const stateMap = doc.getMap('state');
-			const commands = stateMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['42']).toEqual(expect.objectContaining({ id: 42 }));
+			expect(stateMap.get('cmd_42')).toEqual(
+				expect.objectContaining({ id: 42 })
+			);
 			expect(stateMap.get('savedAt')).toEqual(expect.any(Number));
 		});
 
@@ -333,10 +348,8 @@ describe('command-sync', () => {
 			// First, write a running command.
 			mod.writeCommandToSync(MOCK_COMMAND);
 
-			// Verify the command is written.
 			const stateMap = doc.getMap('state');
-			let commands = stateMap.get('commands') as Record<string, unknown>;
-			expect(commands['42']).toBeDefined();
+			expect(stateMap.get('cmd_42')).toBeDefined();
 
 			// Now write a terminal version of the same command.
 			const completedCommand: Command = {
@@ -346,8 +359,7 @@ describe('command-sync', () => {
 			mod.writeCommandToSync(completedCommand);
 
 			// The command should have been removed.
-			commands = stateMap.get('commands') as Record<string, unknown>;
-			expect(commands['42']).toBeUndefined();
+			expect(stateMap.get('cmd_42')).toBeUndefined();
 		});
 
 		it('does nothing when commandDoc is not available', () => {
@@ -408,11 +420,7 @@ describe('command-sync', () => {
 
 				// The retry should have written the command.
 				const stateMap = doc.getMap('state');
-				const commands = stateMap.get('commands') as Record<
-					string,
-					unknown
-				>;
-				expect(commands['42']).toEqual(
+				expect(stateMap.get('cmd_42')).toEqual(
 					expect.objectContaining({ id: 42 })
 				);
 			} finally {
@@ -431,7 +439,7 @@ describe('command-sync', () => {
 			syncConfig.createAwareness(doc);
 
 			// Write a command manually.
-			doc.getMap('state').set('commands', { '42': MOCK_COMMAND });
+			doc.getMap('state').set('cmd_42', MOCK_COMMAND);
 
 			const commands = mod.getCommandsFromSync();
 			expect(commands['42']).toEqual(MOCK_COMMAND);
@@ -723,16 +731,14 @@ describe('command-sync', () => {
 			mod.writeCommandToSync(secondCommand);
 
 			const stateMap = doc.getMap('state');
-			let commands = stateMap.get('commands') as Record<string, unknown>;
-			expect(commands['42']).toBeDefined();
-			expect(commands['43']).toBeDefined();
+			expect(stateMap.get('cmd_42')).toBeDefined();
+			expect(stateMap.get('cmd_43')).toBeDefined();
 
 			// Remove command 42.
 			mod.removeCommandFromSync(42);
 
-			commands = stateMap.get('commands') as Record<string, unknown>;
-			expect(commands['42']).toBeUndefined();
-			expect(commands['43']).toBeDefined();
+			expect(stateMap.get('cmd_42')).toBeUndefined();
+			expect(stateMap.get('cmd_43')).toBeDefined();
 		});
 	});
 
@@ -765,7 +771,7 @@ describe('command-sync', () => {
 			// capturing fetchSpy as origFetch, and replacing window.fetch.
 
 			// Put some data in the doc so it has state to encode.
-			doc.getMap('state').set('commands', { '42': MOCK_COMMAND });
+			doc.getMap('state').set('cmd_42', MOCK_COMMAND);
 
 			// Build a wp-sync request body with the per-user command room having empty updates.
 			const body = JSON.stringify({
@@ -937,12 +943,15 @@ describe('command-sync', () => {
 			const doc = new MockYDoc();
 			syncConfig.createAwareness(doc);
 
-			// Add two commands to the state map — 42 and 43.
+			// Add two commands to the state map. 42 is terminal locally so
+			// cleanup can remove it; 43 stays active.
 			const stateMap = doc.getMap('state');
-			stateMap.set('commands', {
-				'42': { ...MOCK_COMMAND, id: 42 },
-				'43': { ...MOCK_COMMAND, id: 43 },
+			stateMap.set('cmd_42', {
+				...MOCK_COMMAND,
+				id: 42,
+				status: 'completed',
 			});
+			stateMap.set('cmd_43', { ...MOCK_COMMAND, id: 43 });
 
 			// The cleanup polls for the doc every 200ms. Advance to trigger it.
 			jest.advanceTimersByTime(200);
@@ -953,19 +962,57 @@ describe('command-sync', () => {
 			await Promise.resolve();
 			await Promise.resolve();
 
-			// Command 42 should have been removed (not in API response),
-			// command 43 should remain (active in API response).
-			const commands = stateMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['42']).toBeUndefined();
-			expect(commands['43']).toBeDefined();
+			// Command 42 should have been removed (terminal locally and not in
+			// API response); command 43 should remain (active in API response).
+			expect(stateMap.get('cmd_42')).toBeUndefined();
+			expect(stateMap.get('cmd_43')).toBeDefined();
 
 			jest.useRealTimers();
 		});
 
-		it('removes all stale commands regardless of user_id in per-user room', async () => {
+		it('does not remove non-terminal commands even when REST reports them stale', async () => {
+			jest.useFakeTimers();
+
+			window.fetch = jest.fn().mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('ok'),
+			});
+
+			const apiFetchMock = require('@wordpress/api-fetch') as {
+				default: jest.Mock;
+			};
+			// REST reports the command as completed (terminal), but the Y.Doc
+			// still holds the earlier running state — the terminal transition
+			// is presumably in flight from the MCP. Cleanup must leave it
+			// alone so the sync delivery can dispatch CLEAR_ACTIVE_COMMAND.
+			apiFetchMock.default.mockResolvedValue([
+				{ id: 42, status: 'completed' },
+			]);
+
+			const mod = loadModule();
+			await mod.initCommandSync();
+
+			const syncConfig = mockAddEntities.mock.calls[0][0][0].syncConfig;
+			const doc = new MockYDoc();
+			syncConfig.createAwareness(doc);
+
+			const stateMap = doc.getMap('state');
+			stateMap.set('cmd_42', { ...MOCK_COMMAND, id: 42 });
+
+			jest.advanceTimersByTime(200);
+
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// Non-terminal running state is kept; sync is the source of truth.
+			expect(stateMap.get('cmd_42')).toBeDefined();
+
+			jest.useRealTimers();
+		});
+
+		it('removes all stale terminal commands regardless of user_id in per-user room', async () => {
 			jest.useFakeTimers();
 
 			window.fetch = jest.fn().mockResolvedValue({
@@ -986,12 +1033,20 @@ describe('command-sync', () => {
 			const doc = new MockYDoc();
 			syncConfig.createAwareness(doc);
 
-			// Add commands with different user_id values — in per-user rooms,
-			// all commands belong to the room owner, so all should be cleaned.
+			// Both commands are terminal locally, so cleanup should remove
+			// them regardless of user_id (per-user room, all are the owner's).
 			const stateMap = doc.getMap('state');
-			stateMap.set('commands', {
-				'42': { ...MOCK_COMMAND, id: 42, user_id: 1 },
-				'43': { ...MOCK_COMMAND, id: 43, user_id: 99 },
+			stateMap.set('cmd_42', {
+				...MOCK_COMMAND,
+				id: 42,
+				user_id: 1,
+				status: 'completed',
+			});
+			stateMap.set('cmd_43', {
+				...MOCK_COMMAND,
+				id: 43,
+				user_id: 99,
+				status: 'completed',
 			});
 
 			jest.advanceTimersByTime(200);
@@ -1003,12 +1058,8 @@ describe('command-sync', () => {
 			await Promise.resolve();
 
 			// Both commands should be removed (neither is active in the API).
-			const commands = stateMap.get('commands') as Record<
-				string,
-				unknown
-			>;
-			expect(commands['42']).toBeUndefined();
-			expect(commands['43']).toBeUndefined();
+			expect(stateMap.get('cmd_42')).toBeUndefined();
+			expect(stateMap.get('cmd_43')).toBeUndefined();
 
 			jest.useRealTimers();
 		});
@@ -1173,9 +1224,10 @@ describe('command-sync', () => {
 			// Advance timers so the setInterval in subscribeToCommandSync fires.
 			jest.advanceTimersByTime(200);
 
-			// Now change the commands in the state map — the observer should fire.
+			// Now change a command entry in the state map — the observer
+			// should fire and pass the rebuilt id-keyed record.
 			const stateMap = doc.getMap('state');
-			stateMap.set('commands', { '42': MOCK_COMMAND });
+			stateMap.set('cmd_42', MOCK_COMMAND);
 
 			expect(callback).toHaveBeenCalledWith({ '42': MOCK_COMMAND });
 
@@ -1192,7 +1244,7 @@ describe('command-sync', () => {
 			syncConfig.createAwareness(doc);
 
 			// Pre-populate commands.
-			doc.getMap('state').set('commands', { '42': MOCK_COMMAND });
+			doc.getMap('state').set('cmd_42', MOCK_COMMAND);
 
 			const callback = jest.fn();
 			mod.subscribeToCommandSync(callback);
@@ -1200,7 +1252,8 @@ describe('command-sync', () => {
 			// Advance timers so the interval fires.
 			jest.advanceTimersByTime(200);
 
-			// Trigger another observe event with the same commands — should not call callback.
+			// Trigger another observe event that doesn't touch a cmd_* key —
+			// callback shouldn't fire for unrelated keys like savedAt.
 			callback.mockClear();
 			doc.getMap('state').set('savedAt', Date.now());
 
@@ -1247,7 +1300,7 @@ describe('command-sync', () => {
 			unsubscribe();
 
 			// Change commands after unsubscribe — should not fire.
-			doc.getMap('state').set('commands', { '99': MOCK_COMMAND });
+			doc.getMap('state').set('cmd_99', MOCK_COMMAND);
 			expect(callback).not.toHaveBeenCalled();
 
 			jest.useRealTimers();


### PR DESCRIPTION
## Summary

Fixes a flaky race in the pre-publish panel e2e test that turned out to be a real sync bug: status transitions from the MCP could be silently discarded by Y.Map's concurrent-write tiebreak, leaving the panel stuck on "Checking…" forever.

- **Per-command keys.** Both the browser and MCP used to read the shared `commands` object, mutate one entry, and write the whole thing back with `map.set('commands', …)`. When those read-modify-write cycles ran without seeing each other, Y.Map deterministically picked one client's value and silently dropped the other's. Each command now lives at `cmd_${id}` — different commands commute naturally, and same-command updates stay causally ordered.
- **Observer-driven write ordering.** Before mirroring its PATCH response to the Y.Doc, the MCP now waits (up to 2s, via a one-shot observer) for the browser's initial pending write to land. That guarantees the MCP write is causally linked after the browser's pending entry instead of racing it.
- **Flush after status updates.** `updateCommandStatus` now calls `flushQueue()` so the transition reaches the browser on the next tick instead of lagging up to 500ms behind the REST PATCH.
- **Cleanup correctness.** The stale-command cleanup no longer yanks a command whose Y.Doc state is still pre-terminal just because REST reports it terminal — the terminal update is in flight from the MCP, and removing it now would drop the transition before `handleSyncUpdate` can dispatch `CLEAR_ACTIVE_COMMAND`.
- **E2E assertion.** `getByText` doesn't match React-controlled textarea values; the pre-publish test now asserts against the textarea's value with `toHaveValue`.

## Test plan

- [x] `npm run typecheck` in both packages
- [x] `npm run lint`
- [x] `npm test` — 1,211 MCP + 368 plugin unit tests pass
- [x] `npx playwright test pre-publish-panel.spec.ts --repeat-each=50 --workers=8` — 50/50 pass (previously ~80%)
- [ ] CI e2e matrix on this branch