### PR TITLE
feat: make the Compose sidebar resizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 test-results/
 .DS_Store
 .claude/
+.playwright-mcp/
 wordpress-plugin/build/
 wordpress-plugin/node_modules/
 wordpress-plugin/vendor/

--- a/tests/e2e/conversation-sidebar-resize.spec.ts
+++ b/tests/e2e/conversation-sidebar-resize.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Canary e2e test for the ConversationPanel's resize handle.
+ *
+ * The resize hook reaches into Gutenberg's `InterfaceSkeleton` DOM
+ * (`.interface-interface-skeleton__body`, `__sidebar`, and
+ * `.interface-complementary-area`) to drive the sidebar's width. If any of
+ * those class names or the nesting changes upstream, the unit tests keep
+ * passing (they mock Gutenberg) but the feature silently breaks. This
+ * test drives the real editor to catch that.
+ */
+import type { Page } from '@playwright/test';
+import { test, expect } from './test';
+import { openEditor } from './helpers/editor';
+
+const STORAGE_KEY = 'wpce:conversation-sidebar-width';
+
+/**
+ * Dispatch a fake `compose` command into the AI-actions store so the
+ * ConversationPanel mounts and the sidebar opens. No MCP server is
+ * required — this exercises the purely-client resize flow.
+ */
+async function injectComposeCommand(page: Page, postId: number): Promise<void> {
+	await page.evaluate((id) => {
+		type WpGlobal = typeof globalThis & {
+			wp: {
+				data: {
+					select: (store: string) => {
+						getCurrentUser?: () => { id?: number } | undefined;
+					};
+					dispatch: (store: string) => {
+						handleSyncUpdate: (
+							commands: Record<string, unknown>,
+							postId: number,
+							userId: number
+						) => void;
+					};
+				};
+			};
+		};
+		const { data } = (globalThis as WpGlobal).wp;
+		const userId = data.select('core').getCurrentUser?.()?.id ?? 1;
+		data.dispatch('wpce/ai-actions').handleSyncUpdate(
+			{
+				9999: {
+					id: 9999,
+					post_id: id,
+					prompt: 'compose',
+					arguments: {},
+					status: 'awaiting_input',
+					user_id: userId,
+					claimed_by: userId,
+					message: 'canary',
+					result_data: {
+						messages: [
+							{
+								role: 'assistant',
+								content: '<p>Canary message.</p>',
+								timestamp: '2026-01-01T00:00:00Z',
+							},
+						],
+						input_prompt: 'Respond\u2026',
+					},
+					created_at: '2026-01-01T00:00:00Z',
+					updated_at: '2026-01-01T00:00:00Z',
+					expires_at: '2099-12-31 00:00:00',
+				},
+			},
+			id,
+			userId
+		);
+	}, postId);
+}
+
+test.describe('ConversationPanel resize', () => {
+	test('dragging the handle resizes the skeleton sidebar', async ({
+		page,
+		draftPost,
+	}) => {
+		await openEditor(page, draftPost);
+
+		// Reset any persisted width so the default (280) is what we see.
+		await page.evaluate((key: string) => {
+			type WinGlobal = typeof globalThis & {
+				localStorage: { removeItem: (key: string) => void };
+			};
+			(globalThis as WinGlobal).localStorage.removeItem(key);
+		}, STORAGE_KEY);
+
+		await injectComposeCommand(page, draftPost);
+
+		const handle = page.locator('.wpce-conversation-panel__resize-handle');
+		await expect(handle).toBeVisible();
+
+		// Ancestor chain canary: if Gutenberg renames any of these classes
+		// or changes the nesting, one of these expectations fails and the
+		// hook needs updating.
+		const skeleton = page.locator('.interface-interface-skeleton__sidebar');
+		const body = page.locator('.interface-interface-skeleton__body');
+		await expect(
+			body.locator('> .wpce-conversation-panel__resize-handle')
+		).toHaveCount(1);
+		await expect(
+			skeleton.locator('.interface-complementary-area')
+		).toHaveCount(1);
+		await expect(skeleton.locator('.wpce-conversation-panel')).toHaveCount(
+			1
+		);
+
+		// Default width (280) should be written to the skeleton's inline
+		// style now that the sidebar is active.
+		await expect
+			.poll(async () => skeleton.getAttribute('style'))
+			.toMatch(/width:\s*280px/);
+
+		// Drag the handle 100px to the left; the sidebar lives on the
+		// right, so dragging left grows it by the same amount.
+		const box = await handle.boundingBox();
+		if (!box) {
+			throw new Error('resize handle missing bounding box');
+		}
+		const startX = box.x + box.width / 2;
+		const startY = box.y + box.height / 2;
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(startX - 100, startY, { steps: 10 });
+		await page.mouse.up();
+
+		await expect
+			.poll(async () => skeleton.getAttribute('style'))
+			.toMatch(/width:\s*380px/);
+
+		// Width is persisted so the preference survives reloads.
+		const stored = await page.evaluate((key: string): string | null => {
+			type WinGlobal = typeof globalThis & {
+				localStorage: { getItem: (key: string) => string | null };
+			};
+			return (globalThis as WinGlobal).localStorage.getItem(key);
+		}, STORAGE_KEY);
+		expect(stored).toBe('380');
+	});
+});

--- a/tests/e2e/conversation-sidebar-resize.spec.ts
+++ b/tests/e2e/conversation-sidebar-resize.spec.ts
@@ -97,7 +97,9 @@ test.describe('ConversationPanel resize', () => {
 		const skeleton = page.locator('.interface-interface-skeleton__sidebar');
 		const body = page.locator('.interface-interface-skeleton__body');
 		await expect(
-			body.locator('> .wpce-conversation-panel__resize-handle')
+			body.locator(
+				'> .wpce-conversation-panel__resize-handle-slot > .wpce-conversation-panel__resize-handle'
+			)
 		).toHaveCount(1);
 		await expect(
 			skeleton.locator('.interface-complementary-area')
@@ -105,6 +107,29 @@ test.describe('ConversationPanel resize', () => {
 		await expect(skeleton.locator('.wpce-conversation-panel')).toHaveCount(
 			1
 		);
+		// The slot must sit immediately before the sidebar so keyboard tab
+		// order reaches the handle first.
+		const slotIsBeforeSidebar = await page.evaluate((): boolean => {
+			type DocGlobal = typeof globalThis & {
+				document: {
+					querySelector: (selector: string) => {
+						nextElementSibling?: {
+							classList: { contains: (cls: string) => boolean };
+						} | null;
+					} | null;
+				};
+			};
+			const wrapper = (globalThis as DocGlobal).document.querySelector(
+				'.wpce-conversation-panel__resize-handle-slot'
+			);
+			const sibling = wrapper?.nextElementSibling;
+			return (
+				sibling?.classList.contains(
+					'interface-interface-skeleton__sidebar'
+				) ?? false
+			);
+		});
+		expect(slotIsBeforeSidebar).toBe(true);
 
 		// Default width (280) should be written to the skeleton's inline
 		// style now that the sidebar is active.

--- a/wordpress-plugin/src/components/ConversationPanel/constants.ts
+++ b/wordpress-plugin/src/components/ConversationPanel/constants.ts
@@ -1,0 +1,3 @@
+// `getActiveComplementaryArea` returns this identifier (slash form),
+// which is distinct from the DOM id attribute (colon form).
+export const SIDEBAR_ID = 'claudaborative-editing-conversation/conversation';

--- a/wordpress-plugin/src/components/ConversationPanel/index.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/index.tsx
@@ -18,6 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useRef, RawHTML } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { PluginSidebar } from '@wordpress/editor';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -28,7 +29,7 @@ import aiActionsStore from '../../store';
 import SparkleIcon from '../SparkleIcon';
 import { useResizableSidebar } from './use-resizable-sidebar';
 import { SIDEBAR_ID } from './constants';
-import { TERMINAL_STATUSES } from '#shared/commands';
+import { TERMINAL_STATUSES, type CommandSlug } from '#shared/commands';
 import type {
 	ConversationMessage,
 	ConversationResultData,
@@ -38,7 +39,7 @@ import './style.scss';
 
 // Command prompts that open the conversation sidebar on submit (before the
 // MCP server has produced any messages).
-const CONVERSATIONAL_PROMPTS: readonly string[] = ['compose'];
+const CONVERSATIONAL_PROMPTS: readonly CommandSlug[] = ['compose'];
 
 const PROCESSING_WORD_INTERVAL_MS = 2000;
 
@@ -125,7 +126,7 @@ export default function ConversationPanel() {
 		isAwaitingInput ||
 		isRunningWithConversation ||
 		(isInFlight && isConversationalCommand);
-	const shouldShowProcessing = isInFlight && !isAwaitingInput;
+	const shouldShowProcessing = shouldShow && isInFlight && !isAwaitingInput;
 
 	const conversationData = activeCommand
 		? getConversationData(activeCommand.result_data)
@@ -250,7 +251,7 @@ export default function ConversationPanel() {
 		);
 	};
 
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+	const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === 'Enter' && !e.shiftKey) {
 			e.preventDefault();
 			handleSend();

--- a/wordpress-plugin/src/components/ConversationPanel/index.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/index.tsx
@@ -26,6 +26,9 @@ import { useCommands } from '../../hooks/use-commands';
 import { getCommandLabel } from '../../utils/command-i18n';
 import aiActionsStore from '../../store';
 import SparkleIcon from '../SparkleIcon';
+import { useResizableSidebar } from './use-resizable-sidebar';
+import { SIDEBAR_ID } from './constants';
+import { TERMINAL_STATUSES } from '#shared/commands';
 import type {
 	ConversationMessage,
 	ConversationResultData,
@@ -33,7 +36,22 @@ import type {
 
 import './style.scss';
 
-const SIDEBAR_ID = 'claudaborative-editing-conversation/conversation';
+// Command prompts that open the conversation sidebar on submit (before the
+// MCP server has produced any messages).
+const CONVERSATIONAL_PROMPTS: readonly string[] = ['compose'];
+
+const PROCESSING_WORD_INTERVAL_MS = 2000;
+
+// Declared at module scope so the interval effect's `deps.length` reference
+// is stable and doesn't cause restarts across renders.
+const PROCESSING_WORDS = [
+	__('Reading\u2026', 'claudaborative-editing'),
+	__('Thinking\u2026', 'claudaborative-editing'),
+	__('Conjugating\u2026', 'claudaborative-editing'),
+	__('Pondering\u2026', 'claudaborative-editing'),
+	__('Drafting\u2026', 'claudaborative-editing'),
+	__('Outlining\u2026', 'claudaborative-editing'),
+];
 
 /**
  * Extract conversation data from a command's result_data.
@@ -71,17 +89,43 @@ export default function ConversationPanel() {
 	const { createNotice } = useDispatch(noticesStore);
 
 	const [inputValue, setInputValue] = useState('');
+	const [processingWordIndex, setProcessingWordIndex] = useState(0);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const prevStatusRef = useRef<string | null>(null);
 
+	// Single subscription to the interface store for our sidebar's active
+	// state; the hook below reuses this rather than subscribing separately.
+	const isSidebarActive = useSelect((select) => {
+		const iface = select('core/interface') as {
+			getActiveComplementaryArea: (scope: string) => string | null;
+		};
+		return iface.getActiveComplementaryArea('core') === SIDEBAR_ID;
+	}, []);
+
+	const { containerRef, handle: resizeHandle } =
+		useResizableSidebar(isSidebarActive);
+
+	const isPending = activeCommand?.status === 'pending';
+	const isRunning = activeCommand?.status === 'running';
 	const isAwaitingInput = activeCommand?.status === 'awaiting_input';
+	const isInFlight = isPending || isRunning;
+	const isConversationalCommand = !!(
+		activeCommand && CONVERSATIONAL_PROMPTS.includes(activeCommand.prompt)
+	);
 	const isRunningWithConversation =
-		activeCommand?.status === 'running' &&
+		isRunning &&
 		activeCommand.result_data &&
 		Array.isArray(activeCommand.result_data.messages);
 
-	const shouldShow = isAwaitingInput || isRunningWithConversation;
+	// Conversational commands open the sidebar the moment they're pending,
+	// so the user sees the processing indicator instead of staring at
+	// nothing while the MCP server spins up.
+	const shouldShow =
+		isAwaitingInput ||
+		isRunningWithConversation ||
+		(isInFlight && isConversationalCommand);
+	const shouldShowProcessing = isInFlight && !isAwaitingInput;
 
 	const conversationData = activeCommand
 		? getConversationData(activeCommand.result_data)
@@ -104,23 +148,40 @@ export default function ConversationPanel() {
 	const inputPrompt = conversationData?.input_prompt;
 	const planReady = activeCommand?.result_data?.planReady === true;
 
-	// Auto-open the sidebar when entering awaiting_input state or on
-	// initial mount with an existing awaiting_input command.
-	const { enableComplementaryArea } = useDispatch('core/interface') as {
+	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
+		'core/interface'
+	) as {
 		enableComplementaryArea: (scope: string, id: string) => void;
+		disableComplementaryArea: (scope: string) => void;
 	};
 
 	useEffect(() => {
 		const currentStatus = activeCommand?.status ?? null;
+		const prevStatus = prevStatusRef.current;
 
-		if (
+		const enteredAwaitingInput =
 			currentStatus === 'awaiting_input' &&
-			prevStatusRef.current !== 'awaiting_input'
-		) {
+			prevStatus !== 'awaiting_input';
+		// Fire once when a conversational command first enters an in-flight
+		// status; don't re-fire on pending → running transitions.
+		const inFlightStatuses: readonly (string | null)[] = [
+			'pending',
+			'running',
+		];
+		const startedConversationalCommand =
+			isConversationalCommand &&
+			inFlightStatuses.includes(currentStatus) &&
+			!inFlightStatuses.includes(prevStatus);
+
+		if (enteredAwaitingInput || startedConversationalCommand) {
 			enableComplementaryArea?.('core', SIDEBAR_ID);
 		}
 		prevStatusRef.current = currentStatus;
-	}, [activeCommand?.status, enableComplementaryArea]);
+	}, [
+		activeCommand?.status,
+		isConversationalCommand,
+		enableComplementaryArea,
+	]);
 
 	// Auto-scroll to bottom when messages change
 	useEffect(() => {
@@ -136,6 +197,38 @@ export default function ConversationPanel() {
 			return () => clearTimeout(timer);
 		}
 	}, [isAwaitingInput]);
+
+	// Close actions (built-in close button, Cancel button, switching to
+	// another sidebar) all route through `disableComplementaryArea`, which
+	// flips `isSidebarActive` false. When that happens while a non-terminal
+	// command is loaded, cancel it — one watcher for every close path.
+	const isCommandActive = !!(
+		activeCommand &&
+		!TERMINAL_STATUSES.includes(
+			activeCommand.status as (typeof TERMINAL_STATUSES)[number]
+		)
+	);
+	const prevSidebarActiveRef = useRef(isSidebarActive);
+	useEffect(() => {
+		const wasActive = prevSidebarActiveRef.current;
+		prevSidebarActiveRef.current = isSidebarActive;
+		if (wasActive && !isSidebarActive && activeCommand && isCommandActive) {
+			cancel(activeCommand.id);
+		}
+	}, [isSidebarActive, activeCommand, isCommandActive, cancel]);
+
+	useEffect(() => {
+		if (!shouldShowProcessing) {
+			setProcessingWordIndex(0);
+			return;
+		}
+		const interval = setInterval(() => {
+			setProcessingWordIndex(
+				(index) => (index + 1) % PROCESSING_WORDS.length
+			);
+		}, PROCESSING_WORD_INTERVAL_MS);
+		return () => clearInterval(interval);
+	}, [shouldShowProcessing]);
 
 	if (!shouldShow) {
 		return null;
@@ -179,9 +272,9 @@ export default function ConversationPanel() {
 	};
 
 	const handleCancel = () => {
-		if (activeCommand) {
-			cancel(activeCommand.id);
-		}
+		// Closing via the store plays the slide-out animation; the watcher
+		// above cancels the actual command as the sidebar goes inactive.
+		disableComplementaryArea?.('core');
 	};
 
 	const commandLabel = getCommandLabel(activeCommand.prompt);
@@ -191,8 +284,17 @@ export default function ConversationPanel() {
 			name="conversation"
 			title={commandLabel}
 			isPinnable={false}
+			// @ts-expect-error `closeLabel` is supported by the underlying
+			// ComplementaryArea at runtime but not declared on PluginSidebar's
+			// upstream type. Remove this suppression once @wordpress/editor
+			// publishes the prop.
+			closeLabel={__(
+				'Close conversation panel',
+				'claudaborative-editing'
+			)}
 		>
-			<div className="wpce-conversation-panel">
+			<div className="wpce-conversation-panel" ref={containerRef}>
+				{resizeHandle}
 				<div className="wpce-conversation-panel__messages">
 					{messages.map((msg, index) => (
 						<div
@@ -205,15 +307,10 @@ export default function ConversationPanel() {
 						</div>
 					))}
 
-					{!isAwaitingInput && isRunningWithConversation && (
+					{shouldShowProcessing && (
 						<div className="wpce-conversation-panel__processing">
 							<SparkleIcon size={16} active processing />
-							<span>
-								{__(
-									'Processing\u2026',
-									'claudaborative-editing'
-								)}
-							</span>
+							<span>{PROCESSING_WORDS[processingWordIndex]}</span>
 						</div>
 					)}
 

--- a/wordpress-plugin/src/components/ConversationPanel/style.scss
+++ b/wordpress-plugin/src/components/ConversationPanel/style.scss
@@ -9,6 +9,67 @@
 	}
 }
 
+// Resize handle is portalled into `.interface-interface-skeleton__body`
+// (a sibling container to the sidebar) so the pill can straddle the seam
+// between editor and sidebar without being clipped by the skeleton sidebar's
+// own overflow. Its horizontal position is set inline via `right: {width-3}px`
+// so the 7px grab zone stays centered on that seam as the sidebar resizes.
+// stylelint-disable-next-line selector-class-pattern -- WordPress core class.
+.interface-interface-skeleton__body > .wpce-conversation-panel__resize-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 7px;
+	cursor: ew-resize;
+	z-index: 100000;
+	touch-action: none;
+	background: transparent;
+
+	// Full-height seam line that covers the sidebar's 1px border-left so
+	// the entire edge picks up the theme colour on hover.
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 50%;
+		transform: translateX(-50%);
+		width: 1px;
+		background: transparent;
+		transition: background 150ms ease-in-out;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 3px;
+		height: 32px;
+		border-radius: 2px;
+		background: #bbb;
+		transition:
+			background 150ms ease-in-out,
+			width 150ms ease-in-out,
+			border-radius 150ms ease-in-out;
+	}
+
+	&:hover,
+	&:focus-visible,
+	&:active {
+		&::before {
+			background: var(--wp-admin-theme-color, #3858e9);
+		}
+
+		&::after {
+			background: var(--wp-admin-theme-color, #3858e9);
+			width: 5px;
+			border-radius: 3px;
+		}
+	}
+}
+
 .wpce-conversation-panel {
 	display: flex;
 	flex-direction: column;

--- a/wordpress-plugin/src/components/ConversationPanel/style.scss
+++ b/wordpress-plugin/src/components/ConversationPanel/style.scss
@@ -9,19 +9,23 @@
 	}
 }
 
-// Resize handle is portalled into `.interface-interface-skeleton__body`
-// (a sibling container to the sidebar) so the pill can straddle the seam
-// between editor and sidebar without being clipped by the skeleton sidebar's
-// own overflow. Its horizontal position is set inline via `right: {width-3}px`
-// so the 7px grab zone stays centered on that seam as the sidebar resizes.
-// stylelint-disable-next-line selector-class-pattern -- WordPress core class.
-.interface-interface-skeleton__body > .wpce-conversation-panel__resize-handle {
+// Resize handle is portalled into a small wrapper we insert as the
+// previous sibling of `.interface-interface-skeleton__sidebar` inside
+// `.interface-interface-skeleton__body`. That position keeps the pill
+// unclipped by the skeleton sidebar's overflow and also puts the handle
+// before the sidebar content in keyboard tab order. `position: absolute`
+// with `right: {width-3}px` (set inline) centers the 7px grab zone on
+// the seam as the sidebar resizes.
+/* stylelint-disable selector-class-pattern -- BEM class names. */
+.wpce-conversation-panel__resize-handle-slot
+	> .wpce-conversation-panel__resize-handle {
+	/* stylelint-enable selector-class-pattern */
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	width: 7px;
 	cursor: ew-resize;
-	z-index: 100000;
+	z-index: 1000000;
 	touch-action: none;
 	background: transparent;
 

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1591,6 +1591,73 @@ describe('ConversationPanel', () => {
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('300');
 		});
 
+		it('only subscribes to window.resize while the sidebar is active', () => {
+			const addSpy = jest.spyOn(window, 'addEventListener');
+			const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+			// Start with a different sidebar active so our hook's
+			// `isActive` is false and no listener should be attached.
+			mockUseSelect(
+				new Map<unknown, Record<string, (...args: any[]) => any>>([
+					[aiActionsStore, { getCurrentPostId: () => 100 }],
+					[
+						'core/interface',
+						{
+							getActiveComplementaryArea: () =>
+								'edit-post/document',
+						},
+					],
+				])
+			);
+			const { rerender } = mountWithAwaitingInput();
+			expect(addSpy).not.toHaveBeenCalledWith(
+				'resize',
+				expect.any(Function)
+			);
+
+			// Activate our sidebar — listener attaches.
+			mockUseSelect(
+				new Map<unknown, Record<string, (...args: any[]) => any>>([
+					[aiActionsStore, { getCurrentPostId: () => 100 }],
+					[
+						'core/interface',
+						{
+							getActiveComplementaryArea: () =>
+								'claudaborative-editing-conversation/conversation',
+						},
+					],
+				])
+			);
+			act(() => {
+				rerender(<ConversationPanel />);
+			});
+			expect(addSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+
+			// Deactivate — listener detaches.
+			mockUseSelect(
+				new Map<unknown, Record<string, (...args: any[]) => any>>([
+					[aiActionsStore, { getCurrentPostId: () => 100 }],
+					[
+						'core/interface',
+						{
+							getActiveComplementaryArea: () =>
+								'edit-post/document',
+						},
+					],
+				])
+			);
+			act(() => {
+				rerender(<ConversationPanel />);
+			});
+			expect(removeSpy).toHaveBeenCalledWith(
+				'resize',
+				expect.any(Function)
+			);
+
+			addSpy.mockRestore();
+			removeSpy.mockRestore();
+		});
+
 		it('ignores viewport resize events that do not change the max width', () => {
 			mountWithAwaitingInput();
 

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -475,34 +475,36 @@ describe('ConversationPanel', () => {
 
 	it('cycles the processing indicator through its phrases', () => {
 		jest.useFakeTimers();
-		mockedUseCommands.mockReturnValue({
-			activeCommand: {
-				id: 1,
-				prompt: 'compose',
-				status: 'running',
-				post_id: 100,
-				result_data: null,
-			},
-			isResponding: false,
-			respondToCommand: jest.fn(),
-			cancel: jest.fn(),
-		});
+		try {
+			mockedUseCommands.mockReturnValue({
+				activeCommand: {
+					id: 1,
+					prompt: 'compose',
+					status: 'running',
+					post_id: 100,
+					result_data: null,
+				},
+				isResponding: false,
+				respondToCommand: jest.fn(),
+				cancel: jest.fn(),
+			});
 
-		render(<ConversationPanel />);
+			render(<ConversationPanel />);
 
-		expect(screen.getByText('Reading\u2026')).toBeTruthy();
+			expect(screen.getByText('Reading\u2026')).toBeTruthy();
 
-		act(() => {
-			jest.advanceTimersByTime(2000);
-		});
-		expect(screen.getByText('Thinking\u2026')).toBeTruthy();
+			act(() => {
+				jest.advanceTimersByTime(2000);
+			});
+			expect(screen.getByText('Thinking\u2026')).toBeTruthy();
 
-		act(() => {
-			jest.advanceTimersByTime(2000);
-		});
-		expect(screen.getByText('Conjugating\u2026')).toBeTruthy();
-
-		jest.useRealTimers();
+			act(() => {
+				jest.advanceTimersByTime(2000);
+			});
+			expect(screen.getByText('Conjugating\u2026')).toBeTruthy();
+		} finally {
+			jest.useRealTimers();
+		}
 	});
 
 	it('does not show Processing indicator when awaiting_input', () => {
@@ -1636,6 +1638,67 @@ describe('ConversationPanel', () => {
 				configurable: true,
 				writable: true,
 			});
+		});
+
+		it('aborts the drag on pointercancel without committing the width', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			dispatchPointerEventWithId(handle, 'pointermove', {
+				clientX: 400,
+				pointerId: 1,
+			});
+			expect(ancestor.style.width).toBe('380px');
+
+			// OS / browser aborts the gesture — revert DOM, don't persist.
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointercancel', {
+					clientX: 400,
+					pointerId: 1,
+				});
+			});
+
+			expect(ancestor.style.width).toBe('280px');
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+			expect(document.body.style.userSelect).toBe('');
+		});
+
+		it('ignores pointercancel from a different pointerId', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			dispatchPointerEventWithId(handle, 'pointermove', {
+				clientX: 400,
+				pointerId: 1,
+			});
+			// Stray cancel from a different pointer must not interrupt.
+			dispatchPointerEventWithId(handle, 'pointercancel', {
+				clientX: 400,
+				pointerId: 99,
+			});
+			expect(ancestor.style.width).toBe('380px');
+
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointerup', {
+					clientX: 400,
+					pointerId: 1,
+				});
+			});
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('380');
 		});
 
 		it('restores document.body.userSelect on lostpointercapture without committing the width', () => {

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1,6 +1,27 @@
 // jsdom does not implement scrollIntoView
 Element.prototype.scrollIntoView = jest.fn();
 
+// jsdom does not implement PointerEvent. MouseEvent is a close-enough
+// substitute for the pointer-based resize-handle tests: both carry clientX
+// and dispatch the same way through addEventListener('pointermove', ...).
+if (typeof (window as any).PointerEvent === 'undefined') {
+	(window as any).PointerEvent = window.MouseEvent;
+}
+
+// jsdom does not implement the pointer-capture API. The drag handler calls
+// these to keep pointermove flowing while the cursor is over Gutenberg's
+// iframe; stub them so tests don't throw.
+{
+	const proto = Element.prototype as unknown as Record<string, unknown>;
+	if (typeof proto.setPointerCapture !== 'function') {
+		proto.setPointerCapture = function () {};
+		proto.releasePointerCapture = function () {};
+		proto.hasPointerCapture = function () {
+			return false;
+		};
+	}
+}
+
 jest.mock('@wordpress/i18n', () => ({
 	__: jest.fn((str: string) => str),
 }));
@@ -8,11 +29,30 @@ jest.mock('@wordpress/i18n', () => ({
 jest.mock('@wordpress/editor', () => {
 	const { createElement } = require('react');
 	return {
+		// Wrap children in the same ancestor chain Gutenberg renders so
+		// useResizableSidebar's closest() lookups for all three ancestors
+		// (`.interface-interface-skeleton__body`, the skeleton sidebar, and
+		// the complementary area) succeed in jsdom.
 		PluginSidebar: ({ children, title }: any) =>
 			createElement(
 				'div',
-				{ 'data-testid': 'plugin-sidebar', 'data-title': title },
-				children
+				{ className: 'interface-interface-skeleton__body' },
+				createElement(
+					'div',
+					{ className: 'interface-interface-skeleton__sidebar' },
+					createElement(
+						'div',
+						{ className: 'interface-complementary-area' },
+						createElement(
+							'div',
+							{
+								'data-testid': 'plugin-sidebar',
+								'data-title': title,
+							},
+							children
+						)
+					)
+				)
 			),
 	};
 });
@@ -86,7 +126,7 @@ jest.mock('../../../utils/command-i18n', () => ({
 	}),
 }));
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCommands } from '../../../hooks/use-commands';
 import ConversationPanel from '..';
@@ -109,13 +149,17 @@ function mockUseSelect(
 describe('ConversationPanel', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		window.localStorage.clear();
 
 		mockedUseDispatch.mockImplementation((storeNameOrDescriptor?: any) => {
 			if (
 				storeNameOrDescriptor === 'core/interface' ||
 				storeNameOrDescriptor?.name === 'core/interface'
 			) {
-				return { enableComplementaryArea: jest.fn() };
+				return {
+					enableComplementaryArea: jest.fn(),
+					disableComplementaryArea: jest.fn(),
+				};
 			}
 			return { createNotice: jest.fn() };
 		});
@@ -123,6 +167,13 @@ describe('ConversationPanel', () => {
 		mockUseSelect(
 			new Map<unknown, Record<string, (...args: any[]) => any>>([
 				[aiActionsStore, { getCurrentPostId: () => 100 }],
+				[
+					'core/interface',
+					{
+						getActiveComplementaryArea: () =>
+							'claudaborative-editing-conversation/conversation',
+					},
+				],
 			])
 		);
 
@@ -139,7 +190,48 @@ describe('ConversationPanel', () => {
 		expect(container.innerHTML).toBe('');
 	});
 
-	it('returns null when the active command is running without conversation data', () => {
+	it('returns null when a non-conversational command is running without conversation data', () => {
+		mockedUseCommands.mockReturnValue({
+			activeCommand: {
+				id: 1,
+				prompt: 'proofread',
+				status: 'running',
+				post_id: 100,
+				result_data: null,
+			},
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel: jest.fn(),
+		});
+
+		const { container } = render(<ConversationPanel />);
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('opens immediately for a pending compose command', () => {
+		mockedUseCommands.mockReturnValue({
+			activeCommand: {
+				id: 1,
+				prompt: 'compose',
+				status: 'pending',
+				post_id: 100,
+				result_data: null,
+			},
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel: jest.fn(),
+		});
+
+		render(<ConversationPanel />);
+
+		// Panel mounts with the processing indicator visible before the MCP
+		// server has even picked up the command.
+		expect(screen.getByTestId('plugin-sidebar')).toBeTruthy();
+		expect(screen.getByText('Reading\u2026')).toBeTruthy();
+		expect(screen.queryByTestId('conversation-textarea')).toBeNull();
+	});
+
+	it('opens immediately for a running compose command even without conversation data', () => {
 		mockedUseCommands.mockReturnValue({
 			activeCommand: {
 				id: 1,
@@ -153,8 +245,14 @@ describe('ConversationPanel', () => {
 			cancel: jest.fn(),
 		});
 
-		const { container } = render(<ConversationPanel />);
-		expect(container.innerHTML).toBe('');
+		render(<ConversationPanel />);
+
+		// Panel mounts with the processing indicator visible while we wait
+		// for the MCP server's first message.
+		expect(screen.getByTestId('plugin-sidebar')).toBeTruthy();
+		expect(screen.getByText('Reading\u2026')).toBeTruthy();
+		// No awaiting-input input area yet.
+		expect(screen.queryByTestId('conversation-textarea')).toBeNull();
 	});
 
 	it('renders message history when command is awaiting_input with messages', () => {
@@ -371,7 +469,40 @@ describe('ConversationPanel', () => {
 
 		render(<ConversationPanel />);
 
-		expect(screen.getByText('Processing\u2026')).toBeTruthy();
+		// First phrase in the rotating list.
+		expect(screen.getByText('Reading\u2026')).toBeTruthy();
+	});
+
+	it('cycles the processing indicator through its phrases', () => {
+		jest.useFakeTimers();
+		mockedUseCommands.mockReturnValue({
+			activeCommand: {
+				id: 1,
+				prompt: 'compose',
+				status: 'running',
+				post_id: 100,
+				result_data: null,
+			},
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel: jest.fn(),
+		});
+
+		render(<ConversationPanel />);
+
+		expect(screen.getByText('Reading\u2026')).toBeTruthy();
+
+		act(() => {
+			jest.advanceTimersByTime(2000);
+		});
+		expect(screen.getByText('Thinking\u2026')).toBeTruthy();
+
+		act(() => {
+			jest.advanceTimersByTime(2000);
+		});
+		expect(screen.getByText('Conjugating\u2026')).toBeTruthy();
+
+		jest.useRealTimers();
 	});
 
 	it('does not show Processing indicator when awaiting_input', () => {
@@ -398,7 +529,8 @@ describe('ConversationPanel', () => {
 
 		render(<ConversationPanel />);
 
-		expect(screen.queryByText('Processing\u2026')).toBeNull();
+		expect(screen.queryByText('Reading\u2026')).toBeNull();
+		expect(screen.queryByText('Thinking\u2026')).toBeNull();
 	});
 
 	it('shows Approve outline button when planReady is true', () => {
@@ -860,8 +992,21 @@ describe('ConversationPanel', () => {
 		);
 	});
 
-	it('calls cancel with the command ID when Cancel is clicked', () => {
-		const cancel = jest.fn();
+	it('closes the sidebar when Cancel is clicked so the slide-out animation plays', () => {
+		const disableComplementaryArea = jest.fn();
+		mockedUseDispatch.mockImplementation((storeNameOrDescriptor?: any) => {
+			if (
+				storeNameOrDescriptor === 'core/interface' ||
+				storeNameOrDescriptor?.name === 'core/interface'
+			) {
+				return {
+					enableComplementaryArea: jest.fn(),
+					disableComplementaryArea,
+				};
+			}
+			return { createNotice: jest.fn() };
+		});
+
 		mockedUseCommands.mockReturnValue({
 			activeCommand: {
 				id: 7,
@@ -880,13 +1025,385 @@ describe('ConversationPanel', () => {
 			},
 			isResponding: false,
 			respondToCommand: jest.fn(),
-			cancel,
+			cancel: jest.fn(),
 		});
 
 		render(<ConversationPanel />);
 
 		fireEvent.click(screen.getByText('Cancel'));
 
+		expect(disableComplementaryArea).toHaveBeenCalledWith('core');
+	});
+
+	it('cancels the in-flight command when the sidebar becomes inactive', () => {
+		const cancel = jest.fn();
+		const activeCommand = {
+			id: 7,
+			prompt: 'compose',
+			status: 'running',
+			post_id: 100,
+			result_data: null,
+		};
+		mockedUseCommands.mockReturnValue({
+			activeCommand,
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel,
+		});
+
+		const { rerender } = render(<ConversationPanel />);
+
+		// Sidebar was open and command was in-flight — no cancel yet.
+		expect(cancel).not.toHaveBeenCalled();
+
+		// Flip the active complementary area to something else, mimicking
+		// the close button or switching to the block inspector.
+		mockUseSelect(
+			new Map<unknown, Record<string, (...args: any[]) => any>>([
+				[aiActionsStore, { getCurrentPostId: () => 100 }],
+				[
+					'core/interface',
+					{
+						getActiveComplementaryArea: () => 'edit-post/document',
+					},
+				],
+			])
+		);
+
+		rerender(<ConversationPanel />);
+
 		expect(cancel).toHaveBeenCalledWith(7);
+	});
+
+	it('cancels an awaiting_input command when the sidebar becomes inactive', () => {
+		const cancel = jest.fn();
+		mockedUseCommands.mockReturnValue({
+			activeCommand: {
+				id: 9,
+				prompt: 'compose',
+				status: 'awaiting_input',
+				post_id: 100,
+				result_data: {
+					messages: [
+						{
+							role: 'assistant',
+							content: 'What is the topic?',
+							timestamp: '2026-04-06T10:00:00Z',
+						},
+					],
+				},
+			},
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel,
+		});
+
+		const { rerender } = render(<ConversationPanel />);
+
+		expect(cancel).not.toHaveBeenCalled();
+
+		// User clicks close/Cancel — sidebar becomes inactive.
+		mockUseSelect(
+			new Map<unknown, Record<string, (...args: any[]) => any>>([
+				[aiActionsStore, { getCurrentPostId: () => 100 }],
+				[
+					'core/interface',
+					{
+						getActiveComplementaryArea: () => 'edit-post/document',
+					},
+				],
+			])
+		);
+
+		rerender(<ConversationPanel />);
+
+		expect(cancel).toHaveBeenCalledWith(9);
+	});
+
+	it('does not cancel a terminal command when the sidebar becomes inactive', () => {
+		const cancel = jest.fn();
+		mockedUseCommands.mockReturnValue({
+			activeCommand: {
+				id: 11,
+				prompt: 'compose',
+				status: 'completed',
+				post_id: 100,
+				result_data: null,
+			},
+			isResponding: false,
+			respondToCommand: jest.fn(),
+			cancel,
+		});
+
+		const { rerender } = render(<ConversationPanel />);
+
+		mockUseSelect(
+			new Map<unknown, Record<string, (...args: any[]) => any>>([
+				[aiActionsStore, { getCurrentPostId: () => 100 }],
+				[
+					'core/interface',
+					{
+						getActiveComplementaryArea: () => 'edit-post/document',
+					},
+				],
+			])
+		);
+
+		rerender(<ConversationPanel />);
+
+		expect(cancel).not.toHaveBeenCalled();
+	});
+
+	describe('resize', () => {
+		const STORAGE_KEY = 'wpce:conversation-sidebar-width';
+
+		function mountWithAwaitingInput() {
+			mockedUseCommands.mockReturnValue({
+				activeCommand: {
+					id: 1,
+					prompt: 'compose',
+					status: 'awaiting_input',
+					post_id: 100,
+					result_data: {
+						messages: [
+							{
+								role: 'assistant',
+								content: 'Hello',
+								timestamp: '2026-04-06T10:00:00Z',
+							},
+						],
+					},
+				},
+				isResponding: false,
+				respondToCommand: jest.fn(),
+				cancel: jest.fn(),
+			});
+
+			return render(<ConversationPanel />);
+		}
+
+		function getAncestor(): HTMLElement {
+			// The handle is portalled into
+			// `.interface-interface-skeleton__body`, so walk the DOM
+			// directly rather than via the handle.
+			const ancestor = document.querySelector(
+				'.interface-complementary-area'
+			) as HTMLElement | null;
+			if (!ancestor) {
+				throw new Error('Ancestor not found');
+			}
+			return ancestor;
+		}
+
+		it('renders a resize handle when the panel is visible', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			expect(handle).toBeTruthy();
+			expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+			expect(handle.getAttribute('aria-label')).toBe('Resize sidebar');
+		});
+
+		it('applies the default width to the complementary area on mount', () => {
+			mountWithAwaitingInput();
+
+			const ancestor = getAncestor();
+			expect(ancestor.style.width).toBe('280px');
+			expect(ancestor.style.flexBasis).toBe('280px');
+			expect(ancestor.style.position).toBe('relative');
+		});
+
+		it('does not apply width when a different sidebar is active', () => {
+			mockUseSelect(
+				new Map<unknown, Record<string, (...args: any[]) => any>>([
+					[aiActionsStore, { getCurrentPostId: () => 100 }],
+					[
+						'core/interface',
+						{
+							getActiveComplementaryArea: () =>
+								'edit-post/document',
+						},
+					],
+				])
+			);
+
+			mountWithAwaitingInput();
+
+			// When another sidebar is active, the resize handle is not
+			// portalled into the ancestor and inline styles stay untouched.
+			expect(screen.queryByRole('separator')).toBeNull();
+			const ancestor = document.querySelector(
+				'.interface-complementary-area'
+			) as HTMLElement | null;
+			expect(ancestor).toBeTruthy();
+			expect(ancestor!.style.width).toBe('');
+			expect(ancestor!.style.flexBasis).toBe('');
+		});
+
+		it('updates the ancestor width during a pointer drag', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+
+			// Dragging 100px to the left grows the sidebar from 280 → 380.
+			expect(ancestor.style.width).toBe('380px');
+
+			fireEvent.pointerUp(handle, { clientX: 400, pointerId: 1 });
+			expect(ancestor.style.width).toBe('380px');
+		});
+
+		it('clamps the width at MIN_WIDTH when dragging right', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 2000, pointerId: 1 });
+			fireEvent.pointerUp(handle, { clientX: 2000, pointerId: 1 });
+
+			expect(ancestor.style.width).toBe('280px');
+		});
+
+		it('clamps the width at 80% of window.innerWidth when dragging left', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			const max = Math.floor(window.innerWidth * 0.8);
+
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: -10000, pointerId: 1 });
+			fireEvent.pointerUp(handle, { clientX: -10000, pointerId: 1 });
+
+			expect(ancestor.style.width).toBe(`${max}px`);
+		});
+
+		it('writes to localStorage only on pointerup', () => {
+			const setItemSpy = jest.spyOn(
+				window.localStorage.__proto__,
+				'setItem'
+			);
+
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+
+			expect(setItemSpy).not.toHaveBeenCalledWith(
+				STORAGE_KEY,
+				expect.anything()
+			);
+
+			fireEvent.pointerUp(handle, { clientX: 400, pointerId: 1 });
+
+			expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, '380');
+
+			setItemSpy.mockRestore();
+		});
+
+		it('hydrates the width from localStorage on mount', () => {
+			window.localStorage.setItem(STORAGE_KEY, '500');
+
+			mountWithAwaitingInput();
+
+			const ancestor = getAncestor();
+			expect(ancestor.style.width).toBe('500px');
+		});
+
+		it('ignores primary button mismatches on pointerdown', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			// Right-click (button 2) should not start a drag.
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 2,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 100, pointerId: 1 });
+
+			expect(ancestor.style.width).toBe('280px');
+		});
+
+		it('clears inline styles on both skeleton and complementary wrappers when the panel unmounts', () => {
+			const { unmount, container } = mountWithAwaitingInput();
+
+			const skeleton = container.querySelector(
+				'.interface-interface-skeleton__sidebar'
+			) as HTMLElement;
+			const complementary = container.querySelector(
+				'.interface-complementary-area'
+			) as HTMLElement;
+
+			expect(skeleton.style.width).toBe('280px');
+			expect(skeleton.style.flexBasis).toBe('280px');
+			expect(complementary.style.width).toBe('280px');
+			expect(complementary.style.position).toBe('relative');
+
+			unmount();
+
+			expect(skeleton.style.width).toBe('');
+			expect(skeleton.style.flexBasis).toBe('');
+			expect(skeleton.style.maxWidth).toBe('');
+			expect(skeleton.style.minWidth).toBe('');
+			expect(complementary.style.width).toBe('');
+			expect(complementary.style.flexBasis).toBe('');
+			expect(complementary.style.maxWidth).toBe('');
+			expect(complementary.style.minWidth).toBe('');
+			expect(complementary.style.position).toBe('');
+		});
+
+		it('clears skeleton inline styles after a drag when the panel unmounts', () => {
+			const { unmount, container } = mountWithAwaitingInput();
+
+			const skeleton = container.querySelector(
+				'.interface-interface-skeleton__sidebar'
+			) as HTMLElement;
+			const handle = screen.getByRole('separator');
+
+			// Drag to widen the sidebar.
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+			fireEvent.pointerUp(handle, { clientX: 400, pointerId: 1 });
+
+			expect(skeleton.style.width).toBe('380px');
+
+			unmount();
+
+			expect(skeleton.style.width).toBe('');
+			expect(skeleton.style.flexBasis).toBe('');
+			expect(skeleton.style.maxWidth).toBe('');
+			expect(skeleton.style.minWidth).toBe('');
+		});
 	});
 });

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1656,15 +1656,54 @@ describe('ConversationPanel', () => {
 			});
 			expect(ancestor.style.width).toBe('380px');
 
-			// Browser loses capture mid-drag — should restore userSelect
-			// without persisting the in-progress width.
+			// Browser loses capture mid-drag — should restore userSelect,
+			// revert the DOM to the pre-drag width so it matches React
+			// state, and not persist.
 			act(() => {
 				handle.dispatchEvent(
 					new Event('lostpointercapture', { bubbles: true })
 				);
 			});
 			expect(document.body.style.userSelect).toBe('');
+			expect(ancestor.style.width).toBe('280px');
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it('tears down an in-progress drag when the sidebar deactivates', () => {
+			const { rerender } = mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			dispatchPointerEventWithId(handle, 'pointermove', {
+				clientX: 400,
+				pointerId: 1,
+			});
+			expect(document.body.style.userSelect).toBe('none');
+
+			// Flip to a different sidebar (equivalent to close / switch)
+			// so our hook sees `isActive === false` while the drag is
+			// still in flight.
+			mockUseSelect(
+				new Map<unknown, Record<string, (...args: any[]) => any>>([
+					[aiActionsStore, { getCurrentPostId: () => 100 }],
+					[
+						'core/interface',
+						{
+							getActiveComplementaryArea: () =>
+								'edit-post/document',
+						},
+					],
+				])
+			);
+			act(() => {
+				rerender(<ConversationPanel />);
+			});
+
+			expect(document.body.style.userSelect).toBe('');
 		});
 
 		it('does not run cleanup twice if pointerup arrives after lostpointercapture', () => {

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1334,6 +1334,191 @@ describe('ConversationPanel', () => {
 			expect(ancestor.style.width).toBe('500px');
 		});
 
+		it('ignores non-numeric persisted widths and falls back to default', () => {
+			window.localStorage.setItem(STORAGE_KEY, 'not-a-number');
+
+			mountWithAwaitingInput();
+
+			const ancestor = getAncestor();
+			expect(ancestor.style.width).toBe('280px');
+		});
+
+		it('falls back to default width when localStorage throws on read', () => {
+			const getItemSpy = jest
+				.spyOn(window.localStorage.__proto__, 'getItem')
+				.mockImplementation(() => {
+					throw new Error('quota exceeded');
+				});
+
+			mountWithAwaitingInput();
+
+			const ancestor = getAncestor();
+			expect(ancestor.style.width).toBe('280px');
+
+			getItemSpy.mockRestore();
+		});
+
+		it('swallows localStorage errors when persisting the width', () => {
+			const setItemSpy = jest
+				.spyOn(window.localStorage.__proto__, 'setItem')
+				.mockImplementation(() => {
+					throw new Error('quota exceeded');
+				});
+
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			// Should not throw despite the localStorage.setItem error.
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+			fireEvent.pointerUp(handle, { clientX: 400, pointerId: 1 });
+
+			const ancestor = getAncestor();
+			expect(ancestor.style.width).toBe('380px');
+
+			setItemSpy.mockRestore();
+		});
+
+		// jsdom's MouseEvent (our PointerEvent shim) drops `pointerId` from
+		// its init dict, so round-trip it through a writable property.
+		function dispatchPointerEventWithId(
+			target: EventTarget,
+			type: string,
+			init: {
+				clientX?: number;
+				clientY?: number;
+				button?: number;
+				pointerId: number;
+			}
+		): void {
+			const event = new MouseEvent(type, {
+				clientX: init.clientX ?? 0,
+				clientY: init.clientY ?? 0,
+				button: init.button ?? 0,
+				bubbles: true,
+				cancelable: true,
+			});
+			Object.defineProperty(event, 'pointerId', {
+				value: init.pointerId,
+				writable: false,
+			});
+			target.dispatchEvent(event);
+		}
+
+		it('bails out of pointerdown when no resize targets are in the DOM', () => {
+			const { container } = mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			// Initial portalled `right` reflects the default 280 width: 280
+			// minus the handle's 3px half-width.
+			expect(handle.style.right).toBe('277px');
+
+			// Detach the panel from its ancestors so `resolveAncestors`
+			// finds nothing, then fire a drag. The handler must return
+			// early without attaching listeners or moving the handle.
+			const panel = container.querySelector(
+				'.wpce-conversation-panel'
+			) as HTMLElement;
+			panel.remove();
+
+			fireEvent.pointerDown(handle, {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+
+			// If the handler had wired up its listeners, pointermove would
+			// have repositioned the handle to 377px (380 - 3).
+			expect(handle.style.right).toBe('277px');
+		});
+
+		it('ignores pointer events from a different pointerId mid-drag', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointerdown', {
+					clientX: 500,
+					button: 0,
+					pointerId: 1,
+				});
+			});
+
+			// Stray pointer (different id) must not steer the width or end
+			// the drag prematurely.
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointermove', {
+					clientX: 300,
+					pointerId: 99,
+				});
+			});
+			expect(ancestor.style.width).toBe('280px');
+
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointerup', {
+					clientX: 300,
+					pointerId: 99,
+				});
+			});
+			// Original pointer still controls the drag.
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointermove', {
+					clientX: 400,
+					pointerId: 1,
+				});
+				dispatchPointerEventWithId(handle, 'pointerup', {
+					clientX: 400,
+					pointerId: 1,
+				});
+			});
+
+			expect(ancestor.style.width).toBe('380px');
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('380');
+		});
+
+		it('releases pointer capture on drag end when the browser reports it captured', () => {
+			const releaseSpy = jest.fn();
+			const protoHas = Element.prototype.hasPointerCapture;
+			const protoRelease = Element.prototype.releasePointerCapture;
+			// Pretend the browser is still holding capture so the guarded
+			// `releasePointerCapture` call executes.
+			Element.prototype.hasPointerCapture = function () {
+				return true;
+			};
+			Element.prototype.releasePointerCapture = releaseSpy;
+
+			try {
+				mountWithAwaitingInput();
+
+				const handle = screen.getByRole('separator');
+				act(() => {
+					dispatchPointerEventWithId(handle, 'pointerdown', {
+						clientX: 500,
+						button: 0,
+						pointerId: 1,
+					});
+				});
+				act(() => {
+					dispatchPointerEventWithId(handle, 'pointerup', {
+						clientX: 500,
+						pointerId: 1,
+					});
+				});
+
+				expect(releaseSpy).toHaveBeenCalledWith(1);
+			} finally {
+				Element.prototype.hasPointerCapture = protoHas;
+				Element.prototype.releasePointerCapture = protoRelease;
+			}
+		});
+
 		it('ignores primary button mismatches on pointerdown', () => {
 			mountWithAwaitingInput();
 

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1204,6 +1204,49 @@ describe('ConversationPanel', () => {
 			expect(handle.getAttribute('aria-label')).toBe('Resize sidebar');
 		});
 
+		it('places the handle wrapper before the sidebar for tab-order priority', () => {
+			const { container } = mountWithAwaitingInput();
+
+			const body = container.querySelector(
+				'.interface-interface-skeleton__body'
+			) as HTMLElement;
+			const skeleton = body.querySelector(
+				':scope > .interface-interface-skeleton__sidebar'
+			) as HTMLElement;
+			const wrapper = body.querySelector(
+				':scope > .wpce-conversation-panel__resize-handle-slot'
+			) as HTMLElement;
+
+			expect(wrapper).toBeTruthy();
+			// Wrapper must come first so keyboard focus lands on the handle
+			// before entering the sidebar content.
+			expect(wrapper.nextElementSibling).toBe(skeleton);
+			expect(
+				wrapper.querySelector('.wpce-conversation-panel__resize-handle')
+			).toBeTruthy();
+		});
+
+		it('removes the handle wrapper from the DOM when the panel unmounts', () => {
+			const { unmount, container } = mountWithAwaitingInput();
+
+			const body = container.querySelector(
+				'.interface-interface-skeleton__body'
+			) as HTMLElement;
+			expect(
+				body.querySelector(
+					'.wpce-conversation-panel__resize-handle-slot'
+				)
+			).toBeTruthy();
+
+			unmount();
+
+			expect(
+				body.querySelector(
+					'.wpce-conversation-panel__resize-handle-slot'
+				)
+			).toBeNull();
+		});
+
 		it('applies the default width to the complementary area on mount', () => {
 			mountWithAwaitingInput();
 

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1483,6 +1483,69 @@ describe('ConversationPanel', () => {
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('380');
 		});
 
+		it('exposes keyboard/screen-reader semantics on the separator', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			expect(handle.getAttribute('tabindex')).toBe('0');
+			expect(handle.getAttribute('aria-valuenow')).toBe('280');
+			expect(handle.getAttribute('aria-valuemin')).toBe('280');
+			expect(
+				Number(handle.getAttribute('aria-valuemax'))
+			).toBeGreaterThanOrEqual(280);
+		});
+
+		it('grows the sidebar on ArrowLeft and shrinks on ArrowRight', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+			expect(ancestor.style.width).toBe('300px');
+
+			fireEvent.keyDown(handle, { key: 'ArrowRight' });
+			fireEvent.keyDown(handle, { key: 'ArrowRight' });
+			// 300 → 280 (clamped) → still 280.
+			expect(ancestor.style.width).toBe('280px');
+		});
+
+		it('jumps to minimum and maximum on Home and End', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+			const max = Math.floor(window.innerWidth * 0.8);
+
+			fireEvent.keyDown(handle, { key: 'End' });
+			expect(ancestor.style.width).toBe(`${max}px`);
+
+			fireEvent.keyDown(handle, { key: 'Home' });
+			expect(ancestor.style.width).toBe('280px');
+		});
+
+		it('ignores unrelated keys on the separator', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			fireEvent.keyDown(handle, { key: 'Enter' });
+			fireEvent.keyDown(handle, { key: 'a' });
+
+			expect(ancestor.style.width).toBe('280px');
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it('persists the keyboard-adjusted width to localStorage', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('300');
+		});
+
 		it('releases pointer capture on drag end when the browser reports it captured', () => {
 			const releaseSpy = jest.fn();
 			const protoHas = Element.prototype.hasPointerCapture;

--- a/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/test/index.test.tsx
@@ -1589,6 +1589,131 @@ describe('ConversationPanel', () => {
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBe('300');
 		});
 
+		it('ignores viewport resize events that do not change the max width', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const maxBefore = handle.getAttribute('aria-valuemax');
+
+			// innerWidth unchanged — the functional setState bails via the
+			// identity check and no re-render should be needed.
+			act(() => {
+				window.dispatchEvent(new Event('resize'));
+			});
+
+			expect(handle.getAttribute('aria-valuemax')).toBe(maxBefore);
+		});
+
+		it('reacts to viewport resizes by clamping width and updating aria-valuemax', () => {
+			window.localStorage.setItem(STORAGE_KEY, '800');
+
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+			// jsdom default innerWidth is 1024 → max = floor(1024*0.8) = 819.
+			expect(handle.getAttribute('aria-valuemax')).toBe('819');
+			expect(ancestor.style.width).toBe('800px');
+
+			// Shrink the window so the new max drops below 800.
+			const originalInnerWidth = window.innerWidth;
+			Object.defineProperty(window, 'innerWidth', {
+				value: 500,
+				configurable: true,
+				writable: true,
+			});
+			act(() => {
+				window.dispatchEvent(new Event('resize'));
+			});
+
+			// Max recomputed: floor(500*0.8) = 400.
+			expect(handle.getAttribute('aria-valuemax')).toBe('400');
+			// Stored width (800) clamped down to the new max.
+			expect(ancestor.style.width).toBe('400px');
+
+			Object.defineProperty(window, 'innerWidth', {
+				value: originalInnerWidth,
+				configurable: true,
+				writable: true,
+			});
+		});
+
+		it('restores document.body.userSelect on lostpointercapture without committing the width', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			const ancestor = getAncestor();
+
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			expect(document.body.style.userSelect).toBe('none');
+			dispatchPointerEventWithId(handle, 'pointermove', {
+				clientX: 400,
+				pointerId: 1,
+			});
+			expect(ancestor.style.width).toBe('380px');
+
+			// Browser loses capture mid-drag — should restore userSelect
+			// without persisting the in-progress width.
+			act(() => {
+				handle.dispatchEvent(
+					new Event('lostpointercapture', { bubbles: true })
+				);
+			});
+			expect(document.body.style.userSelect).toBe('');
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it('does not run cleanup twice if pointerup arrives after lostpointercapture', () => {
+			mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			dispatchPointerEventWithId(handle, 'pointermove', {
+				clientX: 400,
+				pointerId: 1,
+			});
+			act(() => {
+				handle.dispatchEvent(
+					new Event('lostpointercapture', { bubbles: true })
+				);
+			});
+			// Second teardown (stale pointerup) must not throw nor commit.
+			act(() => {
+				dispatchPointerEventWithId(handle, 'pointerup', {
+					clientX: 400,
+					pointerId: 1,
+				});
+			});
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it('restores document.body.userSelect when the panel unmounts mid-drag', () => {
+			const { unmount } = mountWithAwaitingInput();
+
+			const handle = screen.getByRole('separator');
+			dispatchPointerEventWithId(handle, 'pointerdown', {
+				clientX: 500,
+				button: 0,
+				pointerId: 1,
+			});
+			expect(document.body.style.userSelect).toBe('none');
+
+			act(() => {
+				unmount();
+			});
+
+			expect(document.body.style.userSelect).toBe('');
+		});
+
 		it('releases pointer capture on drag end when the browser reports it captured', () => {
 			const releaseSpy = jest.fn();
 			const protoHas = Element.prototype.hasPointerCapture;

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -46,6 +46,25 @@ function clampWidth(width: number, max = getMaxWidth()): number {
 	return Math.min(max, Math.max(MIN_WIDTH, width));
 }
 
+/**
+ * Tracks the current max-width derived from `window.innerWidth`. Gutenberg
+ * doesn't ship a useViewportWidth hook (`useViewportMatch` is
+ * breakpoint-only, `useResizeObserver` targets a specific element), so we
+ * subscribe to `window.resize` directly.
+ */
+function useViewportMaxWidth(): number {
+	const [maxWidth, setMaxWidth] = useState<number>(() => getMaxWidth());
+	useEffect(() => {
+		function handleResize(): void {
+			const next = getMaxWidth();
+			setMaxWidth((current) => (current === next ? current : next));
+		}
+		window.addEventListener('resize', handleResize);
+		return () => window.removeEventListener('resize', handleResize);
+	}, []);
+	return maxWidth;
+}
+
 function readStoredWidth(): number {
 	try {
 		const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -122,12 +141,26 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		setContainerNode(node);
 	}, []);
 	const [width, setWidth] = useState<number>(() => readStoredWidth());
+	const maxWidth = useViewportMaxWidth();
 	// Portal target = a small wrapper we insert as `__sidebar`'s previous
 	// sibling inside `__body`. Putting it there means keyboard tab order
 	// reaches the handle before the sidebar content (otherwise it'd come
 	// last, after every control inside the panel).
 	const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 	const wrapperRef = useRef<HTMLDivElement | null>(null);
+	// Stores the current drag's teardown so we can run it from any exit
+	// path (pointerup, pointercancel, lostpointercapture, or component
+	// unmount) without leaving `userSelect: none` stuck on the body.
+	const dragCleanupRef = useRef<(() => void) | null>(null);
+
+	// If the viewport shrinks below the stored width, clamp down so we
+	// never display a sidebar wider than the allowed maximum.
+	useEffect(() => {
+		setWidth((current) => {
+			const clamped = clampWidth(current, maxWidth);
+			return clamped === current ? current : clamped;
+		});
+	}, [maxWidth]);
 
 	useLayoutEffect(() => {
 		const { complementary, skeleton, body } =
@@ -172,10 +205,12 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		};
 	}, [containerNode, isActive, width]);
 
-	// Tear down the wrapper on final unmount; width-change re-runs of the
-	// main effect leave it in place.
+	// Tear down the wrapper and any in-progress drag on final unmount.
+	// The drag cleanup restores `userSelect` if we never received a
+	// pointerup/cancel (e.g. the sidebar closed mid-drag).
 	useEffect(() => {
 		return () => {
+			dragCleanupRef.current?.();
 			wrapperRef.current?.remove();
 			wrapperRef.current = null;
 		};
@@ -203,8 +238,8 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 
 			const startX = event.clientX;
 			const startWidth = width;
-			const maxWidth = getMaxWidth();
 			const capturedPointerId = event.pointerId;
+			const capturedMaxWidth = maxWidth;
 			let nextWidth = startWidth;
 
 			const handleMove = (moveEvent: PointerEvent) => {
@@ -214,7 +249,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 				// Sidebar is on the right: dragging left (negative delta)
 				// grows the width.
 				const delta = moveEvent.clientX - startX;
-				nextWidth = clampWidth(startWidth - delta, maxWidth);
+				nextWidth = clampWidth(startWidth - delta, capturedMaxWidth);
 				applyWidth(targets, nextWidth);
 				handleEl.style.right = `${nextWidth - HANDLE_HALF_WIDTH}px`;
 			};
@@ -222,26 +257,46 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 			const prevUserSelect = document.body.style.userSelect;
 			document.body.style.userSelect = 'none';
 
-			const handleUp = (upEvent: PointerEvent) => {
-				if (upEvent.pointerId !== capturedPointerId) {
-					return;
-				}
+			// One teardown fn shared by pointerup, pointercancel,
+			// lostpointercapture, and the unmount path. The ref lets the
+			// unmount effect restore `userSelect` if we never got a
+			// pointerup/cancel (e.g. sidebar closes mid-drag). All event
+			// listeners are removed atomically, so there's no valid path
+			// to a second call.
+			const dispose = (commit: boolean) => {
 				handleEl.removeEventListener('pointermove', handleMove);
 				handleEl.removeEventListener('pointerup', handleUp);
 				handleEl.removeEventListener('pointercancel', handleUp);
+				handleEl.removeEventListener(
+					'lostpointercapture',
+					handleLostCapture
+				);
 				if (handleEl.hasPointerCapture(capturedPointerId)) {
 					handleEl.releasePointerCapture(capturedPointerId);
 				}
 				document.body.style.userSelect = prevUserSelect;
-				setWidth(nextWidth);
-				writeStoredWidth(nextWidth);
+				if (commit) {
+					setWidth(nextWidth);
+					writeStoredWidth(nextWidth);
+				}
+				dragCleanupRef.current = null;
 			};
 
+			const handleUp = (upEvent: PointerEvent) => {
+				if (upEvent.pointerId !== capturedPointerId) {
+					return;
+				}
+				dispose(true);
+			};
+			const handleLostCapture = () => dispose(false);
+
+			dragCleanupRef.current = () => dispose(false);
 			handleEl.addEventListener('pointermove', handleMove);
 			handleEl.addEventListener('pointerup', handleUp);
 			handleEl.addEventListener('pointercancel', handleUp);
+			handleEl.addEventListener('lostpointercapture', handleLostCapture);
 		},
-		[containerNode, width]
+		[containerNode, width, maxWidth]
 	);
 
 	const onKeyDown = useCallback(
@@ -261,18 +316,18 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 					next = MIN_WIDTH;
 					break;
 				case 'End':
-					next = getMaxWidth();
+					next = maxWidth;
 					break;
 			}
 			if (next === null) {
 				return;
 			}
 			event.preventDefault();
-			const clamped = clampWidth(next);
+			const clamped = clampWidth(next, maxWidth);
 			setWidth(clamped);
 			writeStoredWidth(clamped);
 		},
-		[width]
+		[width, maxWidth]
 	);
 
 	const handle =
@@ -291,7 +346,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 						)}
 						aria-valuenow={width}
 						aria-valuemin={MIN_WIDTH}
-						aria-valuemax={getMaxWidth()}
+						aria-valuemax={maxWidth}
 						tabIndex={0}
 						className="wpce-conversation-panel__resize-handle"
 						style={{ right: `${width - HANDLE_HALF_WIDTH}px` }}

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -1,0 +1,268 @@
+/**
+ * Hook that makes the ConversationPanel's PluginSidebar resizable.
+ *
+ * PluginSidebar has no width prop, so we size three Gutenberg
+ * InterfaceSkeleton ancestors of our panel:
+ *
+ * - `.interface-interface-skeleton__sidebar` + `.interface-complementary-area`
+ *   both receive the chosen width (flex layout + fixed-width override).
+ * - `.interface-interface-skeleton__body` hosts a portalled resize handle
+ *   that can straddle the seam between editor and sidebar without being
+ *   clipped by the skeleton sidebar's overflow.
+ *
+ * Width is persisted to localStorage and restored on next mount.
+ */
+
+import {
+	createPortal,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import type { ReactNode, RefCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+
+const STORAGE_KEY = 'wpce:conversation-sidebar-width';
+const HANDLE_HALF_WIDTH = 3;
+const WIDTH_PROPS = ['width', 'flexBasis', 'maxWidth', 'minWidth'] as const;
+
+export const MIN_WIDTH = 280;
+export const DEFAULT_WIDTH = 280;
+
+function getMaxWidth(): number {
+	if (typeof window === 'undefined') {
+		return MIN_WIDTH;
+	}
+	return Math.max(MIN_WIDTH, Math.floor(window.innerWidth * 0.8));
+}
+
+function clampWidth(width: number, max = getMaxWidth()): number {
+	return Math.min(max, Math.max(MIN_WIDTH, width));
+}
+
+function readStoredWidth(): number {
+	if (typeof window === 'undefined') {
+		return DEFAULT_WIDTH;
+	}
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (raw === null) {
+			return DEFAULT_WIDTH;
+		}
+		const value = Number(raw);
+		if (!Number.isFinite(value) || value <= 0) {
+			return DEFAULT_WIDTH;
+		}
+		return clampWidth(value);
+	} catch {
+		return DEFAULT_WIDTH;
+	}
+}
+
+function writeStoredWidth(width: number): void {
+	if (typeof window === 'undefined') {
+		return;
+	}
+	try {
+		window.localStorage.setItem(STORAGE_KEY, String(width));
+	} catch {
+		// Safari private mode and some quota-exhausted states throw on write.
+	}
+}
+
+interface Ancestors {
+	complementary: HTMLElement | null;
+	skeleton: HTMLElement | null;
+	body: HTMLElement | null;
+}
+
+function resolveAncestors(el: HTMLElement | null): Ancestors {
+	if (!el) {
+		return { complementary: null, skeleton: null, body: null };
+	}
+	return {
+		complementary: el.closest<HTMLElement>('.interface-complementary-area'),
+		skeleton: el.closest<HTMLElement>(
+			'.interface-interface-skeleton__sidebar'
+		),
+		body: el.closest<HTMLElement>('.interface-interface-skeleton__body'),
+	};
+}
+
+function applyWidth(nodes: HTMLElement[], width: number): void {
+	const value = `${width}px`;
+	for (const node of nodes) {
+		for (const prop of WIDTH_PROPS) {
+			node.style[prop] = value;
+		}
+	}
+}
+
+function clearWidth(nodes: HTMLElement[]): void {
+	for (const node of nodes) {
+		for (const prop of WIDTH_PROPS) {
+			node.style[prop] = '';
+		}
+	}
+}
+
+interface ResizableSidebar {
+	containerRef: RefCallback<HTMLDivElement>;
+	handle: ReactNode;
+}
+
+export function useResizableSidebar(isActive: boolean): ResizableSidebar {
+	// Callback ref + state: Gutenberg's Slot can mount our Fill's children in
+	// a later commit than our own mount. A plain `useRef` wouldn't re-run
+	// the layout effect when that late attach finally happens.
+	const [containerNode, setContainerNode] = useState<HTMLDivElement | null>(
+		null
+	);
+	const containerRef = useCallback<RefCallback<HTMLDivElement>>((node) => {
+		setContainerNode(node);
+	}, []);
+	const [width, setWidth] = useState<number>(() => readStoredWidth());
+	const [skeletonBody, setSkeletonBody] = useState<HTMLElement | null>(null);
+
+	// Elements we're managing, for the belt-and-braces unmount cleanup.
+	const appliedRef = useRef<HTMLElement[]>([]);
+	// Portalled handle DOM, so pointermove can reposition it in lockstep
+	// with the skeleton during a drag without waiting for React state.
+	const handleRef = useRef<HTMLDivElement | null>(null);
+
+	useLayoutEffect(() => {
+		const { complementary, skeleton, body } =
+			resolveAncestors(containerNode);
+
+		setSkeletonBody((current) => (current === body ? current : body));
+
+		if (!isActive) {
+			return;
+		}
+
+		const targets: HTMLElement[] = [skeleton, complementary].filter(
+			(node): node is HTMLElement => node !== null
+		);
+		if (targets.length === 0) {
+			return;
+		}
+		applyWidth(targets, width);
+		if (complementary) {
+			complementary.style.position = 'relative';
+		}
+		appliedRef.current = targets;
+		return () => {
+			clearWidth(targets);
+			if (complementary) {
+				complementary.style.position = '';
+			}
+			appliedRef.current = [];
+		};
+	}, [containerNode, isActive, width]);
+
+	// If Gutenberg tears down the PluginSidebar before our main effect's
+	// cleanup fires, restore every element we ever touched.
+	useEffect(() => {
+		return () => {
+			const nodes = appliedRef.current;
+			clearWidth(nodes);
+			for (const node of nodes) {
+				node.style.position = '';
+			}
+			appliedRef.current = [];
+			handleRef.current = null;
+		};
+	}, []);
+
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			if (event.button !== 0) {
+				return;
+			}
+			// Re-resolve from the live DOM so the handler can't capture
+			// stale refs after a sidebar re-mount.
+			const { complementary, skeleton } = resolveAncestors(containerNode);
+			const targets: HTMLElement[] = [skeleton, complementary].filter(
+				(node): node is HTMLElement => node !== null
+			);
+			if (targets.length === 0) {
+				return;
+			}
+			event.preventDefault();
+
+			// Pointer capture keeps pointermove flowing even when the cursor
+			// drags across Gutenberg's editor iframe, which otherwise
+			// swallows pointer events going to the outer document.
+			const handleEl = event.currentTarget;
+			handleEl.setPointerCapture(event.pointerId);
+
+			const startX = event.clientX;
+			const startWidth = width;
+			const maxWidth = getMaxWidth();
+			const capturedPointerId = event.pointerId;
+			let nextWidth = startWidth;
+
+			const handleMove = (moveEvent: PointerEvent) => {
+				if (moveEvent.pointerId !== capturedPointerId) {
+					return;
+				}
+				// Sidebar is on the right: dragging left (negative delta)
+				// grows the width.
+				const delta = moveEvent.clientX - startX;
+				nextWidth = clampWidth(startWidth - delta, maxWidth);
+				applyWidth(targets, nextWidth);
+				if (handleRef.current) {
+					handleRef.current.style.right = `${
+						nextWidth - HANDLE_HALF_WIDTH
+					}px`;
+				}
+			};
+
+			const prevUserSelect = document.body.style.userSelect;
+			document.body.style.userSelect = 'none';
+
+			const handleUp = (upEvent: PointerEvent) => {
+				if (upEvent.pointerId !== capturedPointerId) {
+					return;
+				}
+				handleEl.removeEventListener('pointermove', handleMove);
+				handleEl.removeEventListener('pointerup', handleUp);
+				handleEl.removeEventListener('pointercancel', handleUp);
+				if (handleEl.hasPointerCapture(capturedPointerId)) {
+					handleEl.releasePointerCapture(capturedPointerId);
+				}
+				document.body.style.userSelect = prevUserSelect;
+				setWidth(nextWidth);
+				writeStoredWidth(nextWidth);
+			};
+
+			handleEl.addEventListener('pointermove', handleMove);
+			handleEl.addEventListener('pointerup', handleUp);
+			handleEl.addEventListener('pointercancel', handleUp);
+		},
+		[containerNode, width]
+	);
+
+	const handle =
+		isActive && skeletonBody
+			? createPortal(
+					<div
+						ref={handleRef}
+						role="separator"
+						aria-orientation="vertical"
+						aria-label={__(
+							'Resize sidebar',
+							'claudaborative-editing'
+						)}
+						className="wpce-conversation-panel__resize-handle"
+						style={{ right: `${width - HANDLE_HALF_WIDTH}px` }}
+						onPointerDown={onPointerDown}
+					/>,
+					skeletonBody
+				)
+			: null;
+
+	return { containerRef, handle };
+}

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -269,7 +269,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 			const dispose = (commit: boolean) => {
 				handleEl.removeEventListener('pointermove', handleMove);
 				handleEl.removeEventListener('pointerup', handleUp);
-				handleEl.removeEventListener('pointercancel', handleUp);
+				handleEl.removeEventListener('pointercancel', handleCancel);
 				handleEl.removeEventListener(
 					'lostpointercapture',
 					handleLostCapture
@@ -297,12 +297,21 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 				}
 				dispose(true);
 			};
+			// `pointercancel` means the gesture was aborted (OS gesture,
+			// browser cancellation, etc.), so we shouldn't commit the
+			// in-progress width.
+			const handleCancel = (cancelEvent: PointerEvent) => {
+				if (cancelEvent.pointerId !== capturedPointerId) {
+					return;
+				}
+				dispose(false);
+			};
 			const handleLostCapture = () => dispose(false);
 
 			dragCleanupRef.current = () => dispose(false);
 			handleEl.addEventListener('pointermove', handleMove);
 			handleEl.addEventListener('pointerup', handleUp);
-			handleEl.addEventListener('pointercancel', handleUp);
+			handleEl.addEventListener('pointercancel', handleCancel);
 			handleEl.addEventListener('lostpointercapture', handleLostCapture);
 		},
 		[containerNode, width, maxWidth]

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -16,7 +16,9 @@
 import {
 	createPortal,
 	useCallback,
+	useEffect,
 	useLayoutEffect,
+	useRef,
 	useState,
 } from '@wordpress/element';
 import type { ReactNode, RefCallback } from 'react';
@@ -26,6 +28,7 @@ const STORAGE_KEY = 'wpce:conversation-sidebar-width';
 const HANDLE_HALF_WIDTH = 3;
 const KEYBOARD_STEP = 20;
 const WIDTH_PROPS = ['width', 'flexBasis', 'maxWidth', 'minWidth'] as const;
+const HANDLE_SLOT_CLASS = 'wpce-conversation-panel__resize-handle-slot';
 
 export const MIN_WIDTH = 280;
 export const DEFAULT_WIDTH = 280;
@@ -114,20 +117,46 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		setContainerNode(node);
 	}, []);
 	const [width, setWidth] = useState<number>(() => readStoredWidth());
-	const [skeletonBody, setSkeletonBody] = useState<HTMLElement | null>(null);
+	// Portal target = a small wrapper we insert as `__sidebar`'s previous
+	// sibling inside `__body`. Putting it there means keyboard tab order
+	// reaches the handle before the sidebar content (otherwise it'd come
+	// last, after every control inside the panel).
+	const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+	const wrapperRef = useRef<HTMLDivElement | null>(null);
 
 	useLayoutEffect(() => {
 		const { complementary, skeleton, body } =
 			resolveAncestors(containerNode);
 
-		setSkeletonBody((current) => (current === body ? current : body));
-
 		// Gutenberg always renders both wrappers together; if either is
 		// missing (unexpected layout change) we bail instead of applying a
 		// half-baked style.
-		if (!isActive || !skeleton || !complementary) {
+		if (!isActive || !skeleton || !complementary || !body) {
+			if (wrapperRef.current) {
+				wrapperRef.current.remove();
+			}
+			setPortalTarget(null);
 			return;
 		}
+
+		if (!wrapperRef.current) {
+			wrapperRef.current = document.createElement('div');
+			wrapperRef.current.className = HANDLE_SLOT_CLASS;
+		}
+		// Only (re)insert if the wrapper isn't already in the right spot.
+		// insertBefore on a node already at its target position still
+		// detaches and re-attaches, which drops focus from any
+		// descendant — so pressing arrow keys on the handle would move
+		// the sidebar one step and then lose focus.
+		const alreadyPositioned =
+			wrapperRef.current.parentNode === body &&
+			wrapperRef.current.nextSibling === skeleton;
+		if (!alreadyPositioned) {
+			body.insertBefore(wrapperRef.current, skeleton);
+		}
+		setPortalTarget((current) =>
+			current === wrapperRef.current ? current : wrapperRef.current
+		);
 
 		const targets: HTMLElement[] = [skeleton, complementary];
 		applyWidth(targets, width);
@@ -137,6 +166,15 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 			complementary.style.position = '';
 		};
 	}, [containerNode, isActive, width]);
+
+	// Tear down the wrapper on final unmount; width-change re-runs of the
+	// main effect leave it in place.
+	useEffect(() => {
+		return () => {
+			wrapperRef.current?.remove();
+			wrapperRef.current = null;
+		};
+	}, []);
 
 	const onPointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>) => {
@@ -233,7 +271,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 	);
 
 	const handle =
-		isActive && skeletonBody
+		isActive && portalTarget
 			? createPortal(
 					// A focusable resize separator is interactive per ARIA 1.2
 					// (aria-valuenow/min/max make it behave like a slider); the
@@ -255,7 +293,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 						onPointerDown={onPointerDown}
 						onKeyDown={onKeyDown}
 					/>,
-					skeletonBody
+					portalTarget
 				)
 			: null;
 

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 
 const STORAGE_KEY = 'wpce:conversation-sidebar-width';
 const HANDLE_HALF_WIDTH = 3;
+const KEYBOARD_STEP = 20;
 const WIDTH_PROPS = ['width', 'flexBasis', 'maxWidth', 'minWidth'] as const;
 
 export const MIN_WIDTH = 280;
@@ -200,9 +201,44 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		[containerNode, width]
 	);
 
+	const onKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			// Arrow keys nudge by one step; Home/End jump to the extremes.
+			// Left grows the sidebar (matches the drag direction: pulling
+			// the seam leftward widens the panel).
+			let next: number | null = null;
+			switch (event.key) {
+				case 'ArrowLeft':
+					next = width + KEYBOARD_STEP;
+					break;
+				case 'ArrowRight':
+					next = width - KEYBOARD_STEP;
+					break;
+				case 'Home':
+					next = MIN_WIDTH;
+					break;
+				case 'End':
+					next = getMaxWidth();
+					break;
+			}
+			if (next === null) {
+				return;
+			}
+			event.preventDefault();
+			const clamped = clampWidth(next);
+			setWidth(clamped);
+			writeStoredWidth(clamped);
+		},
+		[width]
+	);
+
 	const handle =
 		isActive && skeletonBody
 			? createPortal(
+					// A focusable resize separator is interactive per ARIA 1.2
+					// (aria-valuenow/min/max make it behave like a slider); the
+					// jsx-a11y rule flags `role="separator"` as non-interactive.
+					// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
 					<div
 						role="separator"
 						aria-orientation="vertical"
@@ -210,9 +246,14 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 							'Resize sidebar',
 							'claudaborative-editing'
 						)}
+						aria-valuenow={width}
+						aria-valuemin={MIN_WIDTH}
+						aria-valuemax={getMaxWidth()}
+						tabIndex={0}
 						className="wpce-conversation-panel__resize-handle"
 						style={{ right: `${width - HANDLE_HALF_WIDTH}px` }}
 						onPointerDown={onPointerDown}
+						onKeyDown={onKeyDown}
 					/>,
 					skeletonBody
 				)

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -170,6 +170,9 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		// missing (unexpected layout change) we bail instead of applying a
 		// half-baked style.
 		if (!isActive || !skeleton || !complementary || !body) {
+			// Sidebar closed mid-drag — tear down the in-progress drag so
+			// `document.body.style.userSelect` doesn't stay stuck at 'none'.
+			dragCleanupRef.current?.();
 			if (wrapperRef.current) {
 				wrapperRef.current.remove();
 			}
@@ -278,6 +281,12 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 				if (commit) {
 					setWidth(nextWidth);
 					writeStoredWidth(nextWidth);
+				} else {
+					// Revert DOM to pre-drag state so it matches React
+					// state and ARIA — otherwise the user would see the
+					// sidebar snap back on the next render.
+					applyWidth(targets, startWidth);
+					handleEl.style.right = `${startWidth - HANDLE_HALF_WIDTH}px`;
 				}
 				dragCleanupRef.current = null;
 			};

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -50,18 +50,29 @@ function clampWidth(width: number, max = getMaxWidth()): number {
  * Tracks the current max-width derived from `window.innerWidth`. Gutenberg
  * doesn't ship a useViewportWidth hook (`useViewportMatch` is
  * breakpoint-only, `useResizeObserver` targets a specific element), so we
- * subscribe to `window.resize` directly.
+ * subscribe to `window.resize` directly — but only when `enabled`, since
+ * `ConversationPanel` stays mounted as a plugin and would otherwise tie up
+ * a listener for the entire editor session even when the sidebar is closed.
+ *
+ * @param enabled Whether to subscribe to resize events.
+ * @return The clamped max-width that tracks the viewport while enabled.
  */
-function useViewportMaxWidth(): number {
+function useViewportMaxWidth(enabled: boolean): number {
 	const [maxWidth, setMaxWidth] = useState<number>(() => getMaxWidth());
 	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
 		function handleResize(): void {
 			const next = getMaxWidth();
 			setMaxWidth((current) => (current === next ? current : next));
 		}
+		// Sync up on re-enable in case the viewport changed while the
+		// listener was detached.
+		handleResize();
 		window.addEventListener('resize', handleResize);
 		return () => window.removeEventListener('resize', handleResize);
-	}, []);
+	}, [enabled]);
 	return maxWidth;
 }
 
@@ -141,7 +152,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		setContainerNode(node);
 	}, []);
 	const [width, setWidth] = useState<number>(() => readStoredWidth());
-	const maxWidth = useViewportMaxWidth();
+	const maxWidth = useViewportMaxWidth(isActive);
 	// Portal target = a small wrapper we insert as `__sidebar`'s previous
 	// sibling inside `__body`. Putting it there means keyboard tab order
 	// reaches the handle before the sidebar content (otherwise it'd come

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -16,9 +16,7 @@
 import {
 	createPortal,
 	useCallback,
-	useEffect,
 	useLayoutEffect,
-	useRef,
 	useState,
 } from '@wordpress/element';
 import type { ReactNode, RefCallback } from 'react';
@@ -32,9 +30,6 @@ export const MIN_WIDTH = 280;
 export const DEFAULT_WIDTH = 280;
 
 function getMaxWidth(): number {
-	if (typeof window === 'undefined') {
-		return MIN_WIDTH;
-	}
 	return Math.max(MIN_WIDTH, Math.floor(window.innerWidth * 0.8));
 }
 
@@ -43,9 +38,6 @@ function clampWidth(width: number, max = getMaxWidth()): number {
 }
 
 function readStoredWidth(): number {
-	if (typeof window === 'undefined') {
-		return DEFAULT_WIDTH;
-	}
 	try {
 		const raw = window.localStorage.getItem(STORAGE_KEY);
 		if (raw === null) {
@@ -62,9 +54,6 @@ function readStoredWidth(): number {
 }
 
 function writeStoredWidth(width: number): void {
-	if (typeof window === 'undefined') {
-		return;
-	}
 	try {
 		window.localStorage.setItem(STORAGE_KEY, String(width));
 	} catch {
@@ -126,55 +115,27 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 	const [width, setWidth] = useState<number>(() => readStoredWidth());
 	const [skeletonBody, setSkeletonBody] = useState<HTMLElement | null>(null);
 
-	// Elements we're managing, for the belt-and-braces unmount cleanup.
-	const appliedRef = useRef<HTMLElement[]>([]);
-	// Portalled handle DOM, so pointermove can reposition it in lockstep
-	// with the skeleton during a drag without waiting for React state.
-	const handleRef = useRef<HTMLDivElement | null>(null);
-
 	useLayoutEffect(() => {
 		const { complementary, skeleton, body } =
 			resolveAncestors(containerNode);
 
 		setSkeletonBody((current) => (current === body ? current : body));
 
-		if (!isActive) {
+		// Gutenberg always renders both wrappers together; if either is
+		// missing (unexpected layout change) we bail instead of applying a
+		// half-baked style.
+		if (!isActive || !skeleton || !complementary) {
 			return;
 		}
 
-		const targets: HTMLElement[] = [skeleton, complementary].filter(
-			(node): node is HTMLElement => node !== null
-		);
-		if (targets.length === 0) {
-			return;
-		}
+		const targets: HTMLElement[] = [skeleton, complementary];
 		applyWidth(targets, width);
-		if (complementary) {
-			complementary.style.position = 'relative';
-		}
-		appliedRef.current = targets;
+		complementary.style.position = 'relative';
 		return () => {
 			clearWidth(targets);
-			if (complementary) {
-				complementary.style.position = '';
-			}
-			appliedRef.current = [];
+			complementary.style.position = '';
 		};
 	}, [containerNode, isActive, width]);
-
-	// If Gutenberg tears down the PluginSidebar before our main effect's
-	// cleanup fires, restore every element we ever touched.
-	useEffect(() => {
-		return () => {
-			const nodes = appliedRef.current;
-			clearWidth(nodes);
-			for (const node of nodes) {
-				node.style.position = '';
-			}
-			appliedRef.current = [];
-			handleRef.current = null;
-		};
-	}, []);
 
 	const onPointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>) => {
@@ -184,12 +145,10 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 			// Re-resolve from the live DOM so the handler can't capture
 			// stale refs after a sidebar re-mount.
 			const { complementary, skeleton } = resolveAncestors(containerNode);
-			const targets: HTMLElement[] = [skeleton, complementary].filter(
-				(node): node is HTMLElement => node !== null
-			);
-			if (targets.length === 0) {
+			if (!skeleton || !complementary) {
 				return;
 			}
+			const targets: HTMLElement[] = [skeleton, complementary];
 			event.preventDefault();
 
 			// Pointer capture keeps pointermove flowing even when the cursor
@@ -213,11 +172,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 				const delta = moveEvent.clientX - startX;
 				nextWidth = clampWidth(startWidth - delta, maxWidth);
 				applyWidth(targets, nextWidth);
-				if (handleRef.current) {
-					handleRef.current.style.right = `${
-						nextWidth - HANDLE_HALF_WIDTH
-					}px`;
-				}
+				handleEl.style.right = `${nextWidth - HANDLE_HALF_WIDTH}px`;
 			};
 
 			const prevUserSelect = document.body.style.userSelect;
@@ -249,7 +204,6 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 		isActive && skeletonBody
 			? createPortal(
 					<div
-						ref={handleRef}
 						role="separator"
 						aria-orientation="vertical"
 						aria-label={__(

--- a/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
+++ b/wordpress-plugin/src/components/ConversationPanel/use-resizable-sidebar.tsx
@@ -21,7 +21,12 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import type { ReactNode, RefCallback } from 'react';
+import type {
+	KeyboardEvent as ReactKeyboardEvent,
+	PointerEvent as ReactPointerEvent,
+	ReactNode,
+	RefCallback,
+} from 'react';
 import { __ } from '@wordpress/i18n';
 
 const STORAGE_KEY = 'wpce:conversation-sidebar-width';
@@ -177,7 +182,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 	}, []);
 
 	const onPointerDown = useCallback(
-		(event: React.PointerEvent<HTMLDivElement>) => {
+		(event: ReactPointerEvent<HTMLDivElement>) => {
 			if (event.button !== 0) {
 				return;
 			}
@@ -240,7 +245,7 @@ export function useResizableSidebar(isActive: boolean): ResizableSidebar {
 	);
 
 	const onKeyDown = useCallback(
-		(event: React.KeyboardEvent<HTMLDivElement>) => {
+		(event: ReactKeyboardEvent<HTMLDivElement>) => {
 			// Arrow keys nudge by one step; Home/End jump to the extremes.
 			// Left grows the sidebar (matches the drag direction: pulling
 			// the seam leftward widens the panel).


### PR DESCRIPTION
## Summary

Closes #80.

- Drag the left edge of the conversation sidebar to resize it; width persists across sessions via `localStorage`. The grab zone is a 7px strip on the seam between editor and sidebar, with a subtle pill indicator that expands and colours on hover/focus/active.
- Keyboard-operable: the resize separator is focusable (`tabIndex={0}`) with `aria-valuenow` / `aria-valuemin` / `aria-valuemax`, and responds to Left/Right arrows (20px steps) and Home/End (min/max).
- Conversational commands (currently just `compose`) open the sidebar the moment they're `pending`, with a cycling processing indicator ("Reading…", "Thinking…", "Conjugating…", "Pondering…", "Drafting…", "Outlining…") so the user doesn't stare at nothing while the MCP server spins up.
- The built-in close button and the Cancel button both route through `disableComplementaryArea` so the slide-out animation plays, and a single sidebar-close watcher cancels the in-flight command via the shared `TERMINAL_STATUSES` predicate (so `awaiting_input` is correctly treated as cancellable).
- Pointer capture on the handle keeps pointer events flowing while the cursor drags across Gutenberg's editor iframe.
- An e2e canary asserts the Gutenberg `InterfaceSkeleton` DOM contract the resize hook depends on (`.interface-interface-skeleton__body`, `__sidebar`, `.interface-complementary-area` and their nesting), so upstream class-name or structural changes fail loudly instead of silently breaking the feature.
- 100% line/branch/function/statement coverage on `use-resizable-sidebar.tsx` (52 jest tests).

## Test plan

- [ ] `cd wordpress-plugin && npm run test` — 52 unit tests including resize drag, keyboard resize, clamping, persistence, hydration, cleanup on unmount, and cancel-on-close watcher.
- [ ] `cd wordpress-plugin && npm run test:coverage -- --collectCoverageFrom='src/components/ConversationPanel/use-resizable-sidebar.tsx'` — 100% across all four metrics.
- [ ] `npm run typecheck` and `npm run lint` — both clean at repo root and in `wordpress-plugin/`.
- [ ] `npm run test:e2e -- conversation-sidebar-resize` — canary drags the handle in a real WP Playground editor and verifies the skeleton width updates + persists.
- [ ] Manual smoke: `npm run dev:wp`, trigger a Compose command, verify the sidebar opens immediately with rotating phrases, resize by dragging the left edge or tabbing to the separator and using arrow keys, close with X or Cancel — both play the slide-out and cancel the command.