### PR TITLE
feat: add wp_view_post to read other posts without leaving the current one

### DIFF
--- a/src/prompts/prompt-content.ts
+++ b/src/prompts/prompt-content.ts
@@ -107,6 +107,7 @@ Available tools:
 - wp_set_categories, wp_set_tags — update taxonomy
 - wp_set_excerpt — update the post excerpt
 - wp_read_post — re-read the post after making changes
+- wp_view_post — read another post on the site for reference, without closing the current one
 
 Work block by block. Do not try to replace the entire post at once. Preserve the overall structure unless restructuring was requested. After completing edits, use wp_save to save the post.`;
 }
@@ -264,6 +265,8 @@ Ask me 2-3 focused questions to understand what I want to write about. Ask one q
 - What tone or style should it have?
 
 Do NOT ask all questions at once — ask one, wait for my response, then ask the next based on what I said. Skip questions if the answer is already obvious from context or prior answers.
+
+If it would help inform your questions or the outline, you can research existing posts on this site without leaving the current draft: use wp_list_posts to browse and wp_view_post to read any post by ID. The current post stays open and unaffected.
 
 ### Phase 2: Outlining
 Based on my answers, propose an outline with 4-8 sections. For each section, include:

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -983,6 +983,61 @@ export class SessionManager {
 		return renderBlock(block, index);
 	}
 
+	/**
+	 * Render any post by ID as Claude-friendly text. Read-only via REST —
+	 * does not touch the Y.Doc, so the currently-open post (if any) is
+	 * undisturbed. Use for research while keeping an editing session open.
+	 */
+	async viewPost(postId: number): Promise<string> {
+		this.requireState('connected', 'editing');
+
+		const post = await this.apiClient.getPost(postId);
+
+		const title = post.title.raw ?? post.title.rendered;
+		const blocks = parseBlocks(post.content.raw ?? '').map(
+			parsedBlockToBlock
+		);
+
+		// Resolve category/tag IDs to names. Best-effort: if the lookup
+		// fails the metadata is shown without them rather than the whole
+		// call failing.
+		let categoryNames: string[] | undefined;
+		let tagNames: string[] | undefined;
+		if (post.categories && post.categories.length > 0) {
+			try {
+				const cats = await this.apiClient.getTerms(
+					'categories',
+					post.categories
+				);
+				categoryNames = cats.map((t) => t.name);
+			} catch {
+				// Non-critical
+			}
+		}
+		if (post.tags && post.tags.length > 0) {
+			try {
+				const tags = await this.apiClient.getTerms('tags', post.tags);
+				tagNames = tags.map((t) => t.name);
+			} catch {
+				// Non-critical
+			}
+		}
+
+		const metadata: PostMetadata = {
+			status: post.status,
+			date: post.date ?? undefined,
+			slug: post.slug,
+			sticky: post.sticky,
+			commentStatus: post.comment_status,
+			excerpt: post.excerpt.raw || undefined,
+			categories: categoryNames,
+			tags: tagNames,
+			featuredImage: post.featured_media,
+		};
+
+		return renderPost(title, blocks, metadata);
+	}
+
 	// --- Editing ---
 
 	/**

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -818,29 +818,13 @@ export class SessionManager {
 		this.state = 'editing';
 
 		// Resolve category/tag IDs to names for display in readPost().
-		// Runs after state is set so it doesn't block the editing transition.
-		// Errors are swallowed — term names are informational, not critical.
-		try {
-			const catIds = post.categories ?? [];
-			if (catIds.length > 0) {
-				const cats = await this.apiClient.getTerms(
-					'categories',
-					catIds
-				);
-				this._cachedCategories = cats.map((t) => t.name);
-			}
-		} catch {
-			// Non-critical: readPost() will omit categories
-		}
-		try {
-			const tagIds = post.tags ?? [];
-			if (tagIds.length > 0) {
-				const tags = await this.apiClient.getTerms('tags', tagIds);
-				this._cachedTags = tags.map((t) => t.name);
-			}
-		} catch {
-			// Non-critical: readPost() will omit tags
-		}
+		// Runs in parallel after the state transition so it doesn't block
+		// the editing transition. Term names are informational, so lookup
+		// failures leave the cached arrays empty.
+		[this._cachedCategories, this._cachedTags] = await Promise.all([
+			this.resolveTermNames('categories', post.categories),
+			this.resolveTermNames('tags', post.tags),
+		]);
 	}
 
 	/**
@@ -998,30 +982,10 @@ export class SessionManager {
 			parsedBlockToBlock
 		);
 
-		// Resolve category/tag IDs to names. Best-effort: if the lookup
-		// fails the metadata is shown without them rather than the whole
-		// call failing.
-		let categoryNames: string[] | undefined;
-		let tagNames: string[] | undefined;
-		if (post.categories && post.categories.length > 0) {
-			try {
-				const cats = await this.apiClient.getTerms(
-					'categories',
-					post.categories
-				);
-				categoryNames = cats.map((t) => t.name);
-			} catch {
-				// Non-critical
-			}
-		}
-		if (post.tags && post.tags.length > 0) {
-			try {
-				const tags = await this.apiClient.getTerms('tags', post.tags);
-				tagNames = tags.map((t) => t.name);
-			} catch {
-				// Non-critical
-			}
-		}
+		const [categoryNames, tagNames] = await Promise.all([
+			this.resolveTermNames('categories', post.categories),
+			this.resolveTermNames('tags', post.tags),
+		]);
 
 		const metadata: PostMetadata = {
 			status: post.status,
@@ -1030,12 +994,32 @@ export class SessionManager {
 			sticky: post.sticky,
 			commentStatus: post.comment_status,
 			excerpt: post.excerpt.raw || undefined,
-			categories: categoryNames,
-			tags: tagNames,
+			categories: categoryNames.length > 0 ? categoryNames : undefined,
+			tags: tagNames.length > 0 ? tagNames : undefined,
 			featuredImage: post.featured_media,
 		};
 
 		return renderPost(title, blocks, metadata);
+	}
+
+	/**
+	 * Resolve taxonomy term IDs to display names. Best-effort: returns []
+	 * when there are no IDs or the lookup fails, so callers can treat the
+	 * metadata as informational.
+	 */
+	private async resolveTermNames(
+		taxonomy: 'categories' | 'tags',
+		ids: number[] | undefined
+	): Promise<string[]> {
+		if (!ids || ids.length === 0) {
+			return [];
+		}
+		try {
+			const terms = await this.apiClient.getTerms(taxonomy, ids);
+			return terms.map((t) => t.name);
+		} catch {
+			return [];
+		}
 	}
 
 	// --- Editing ---

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -23,4 +23,16 @@ export const readTools: ToolDefinition[] = [
 		execute: (session, { index }: { index: string }) =>
 			session.readBlock(index),
 	},
+	{
+		name: 'wp_view_post',
+		description:
+			'Read any WordPress post by ID without opening it for editing. Returns the saved (committed) content as a block listing. Use this to research other posts while keeping the current post open.',
+		inputSchema: {
+			postId: z.number().describe('The post ID to read'),
+		},
+		availableIn: ['connected', 'editing'],
+		tags: ['reading', 'posts'],
+		execute: (session, { postId }: { postId: number }) =>
+			session.viewPost(postId),
+	},
 ];

--- a/tests/unit/prompts/prompt-content.test.ts
+++ b/tests/unit/prompts/prompt-content.test.ts
@@ -84,6 +84,11 @@ describe('buildEditContent', () => {
 		expect(result).toContain('wp_insert_block');
 		expect(result).toContain('wp_save');
 	});
+
+	it('mentions wp_view_post for cross-post research', () => {
+		const result = buildEditContent('Hello world', 'improve clarity');
+		expect(result).toContain('wp_view_post');
+	});
 });
 
 describe('buildReviewContent', () => {
@@ -167,6 +172,12 @@ describe('buildComposeContent', () => {
 		const result = buildComposeContent('Hello world', true);
 		expect(result).toContain('wp_update_command_status');
 		expect(result).toContain('planReady');
+	});
+
+	it('mentions cross-post research tools in discovery', () => {
+		const result = buildComposeContent('Hello world', true);
+		expect(result).toContain('wp_list_posts');
+		expect(result).toContain('wp_view_post');
 	});
 });
 

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -545,6 +545,94 @@ describe('SessionManager', () => {
 		});
 	});
 
+	describe('viewPost()', () => {
+		const otherPost: WPPost = {
+			id: 99,
+			title: { rendered: 'Other Post', raw: 'Other Post' },
+			content: {
+				rendered: '<p>Other body</p>',
+				raw: '<!-- wp:paragraph -->\n<p>Other body</p>\n<!-- /wp:paragraph -->',
+			},
+			excerpt: { rendered: '', raw: 'Other excerpt' },
+			status: 'publish',
+			type: 'post',
+			slug: 'other-post',
+			author: 1,
+			date: '2026-02-02T00:00:00',
+			modified: '2026-02-02T00:00:00',
+			categories: [5],
+			tags: [7],
+			featured_media: 0,
+			comment_status: 'open',
+			sticky: false,
+		};
+
+		it('renders any post fetched via REST without touching state', async () => {
+			await connectSession(session);
+			mockGetPost.mockResolvedValue(otherPost);
+			mockGetTerms
+				.mockResolvedValueOnce([
+					{
+						id: 5,
+						name: 'News',
+						slug: 'news',
+						taxonomy: 'category',
+					},
+				])
+				.mockResolvedValueOnce([
+					{ id: 7, name: 'launch', slug: 'launch', taxonomy: 'tag' },
+				]);
+
+			const text = await session.viewPost(99);
+
+			expect(mockGetPost).toHaveBeenCalledWith(99);
+			expect(text).toContain('Title: "Other Post"');
+			expect(text).toContain('Status: publish');
+			expect(text).toContain('Slug: other-post');
+			expect(text).toContain('Excerpt: "Other excerpt"');
+			expect(text).toContain('Categories: News');
+			expect(text).toContain('Tags: launch');
+			expect(text).toContain('core/paragraph');
+			expect(text).toContain('Other body');
+			expect(session.getState()).toBe('connected');
+		});
+
+		it('leaves the currently-open post undisturbed', async () => {
+			await connectAndOpen(session);
+			mockGetPost.mockResolvedValueOnce({
+				...otherPost,
+				categories: undefined,
+				tags: undefined,
+			});
+
+			const before = session.readPost();
+			await session.viewPost(99);
+			const after = session.readPost();
+
+			expect(after).toBe(before);
+			expect(session.getState()).toBe('editing');
+			expect(session.getCurrentPost()?.id).toBe(42);
+		});
+
+		it('omits categories and tags when term lookup fails', async () => {
+			await connectSession(session);
+			mockGetPost.mockResolvedValue(otherPost);
+			mockGetTerms.mockRejectedValue(new Error('boom'));
+
+			const text = await session.viewPost(99);
+
+			expect(text).not.toContain('Categories:');
+			expect(text).not.toContain('Tags:');
+			expect(text).toContain('Title: "Other Post"');
+		});
+
+		it('throws when disconnected', async () => {
+			await expect(session.viewPost(99)).rejects.toThrow(
+				/requires state/
+			);
+		});
+	});
+
 	describe('updateBlock()', () => {
 		it('modifies block content in doc', async () => {
 			await connectAndOpen(session);

--- a/tests/unit/tools/helpers.ts
+++ b/tests/unit/tools/helpers.ts
@@ -176,6 +176,7 @@ export function createMockSession(
 		closePost: vi.fn().mockResolvedValue(undefined),
 		readPost: vi.fn().mockReturnValue(postContent),
 		readBlock: vi.fn().mockReturnValue(blockContent),
+		viewPost: vi.fn().mockResolvedValue(postContent),
 		updateBlock: vi.fn().mockResolvedValue(undefined),
 		editBlockText: vi.fn().mockReturnValue(editBlockTextResult),
 		insertBlock: vi.fn().mockResolvedValue(undefined),

--- a/tests/unit/tools/read.test.ts
+++ b/tests/unit/tools/read.test.ts
@@ -32,9 +32,10 @@ describe('read tools', () => {
 		);
 	});
 
-	it('registers wp_read_post and wp_read_block', () => {
+	it('registers wp_read_post, wp_read_block, and wp_view_post', () => {
 		expect(server.registeredTools.has('wp_read_post')).toBe(true);
 		expect(server.registeredTools.has('wp_read_block')).toBe(true);
+		expect(server.registeredTools.has('wp_view_post')).toBe(true);
 	});
 
 	describe('wp_read_post', () => {
@@ -102,6 +103,43 @@ describe('read tools', () => {
 
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain('Block not found');
+		});
+	});
+
+	describe('wp_view_post', () => {
+		it('returns rendered content for the requested post', async () => {
+			(
+				session.viewPost as ReturnType<typeof import('vitest').vi.fn>
+			).mockResolvedValue(
+				'Title: "Other Post"\n\n[0] core/paragraph\n  "Other content"'
+			);
+
+			const tool = server.registeredTools.get('wp_view_post');
+			assertDefined(tool);
+			const result = await tool.handler({ postId: 99 });
+
+			expect(session.viewPost).toHaveBeenCalledWith(99);
+			expect(result.content[0].text).toContain('Title: "Other Post"');
+			expect(result.content[0].text).toContain('Other content');
+		});
+
+		it('returns error when the post is not found', async () => {
+			(
+				session.viewPost as ReturnType<typeof import('vitest').vi.fn>
+			).mockRejectedValue(new Error('Post 999 not found'));
+
+			const tool = server.registeredTools.get('wp_view_post');
+			assertDefined(tool);
+			const result = await tool.handler({ postId: 999 });
+
+			expect(result.isError).toBe(true);
+			expect(result.content[0].text).toContain('Post 999 not found');
+		});
+
+		it('is exposed in connected and editing states', () => {
+			const def = readTools.find((t) => t.name === 'wp_view_post');
+			assertDefined(def);
+			expect(def.availableIn).toEqual(['connected', 'editing']);
 		});
 	});
 });

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -14,8 +14,8 @@ import type { ToolDefinition } from '../../../src/tools/definitions.js';
 
 describe('tools/registry', () => {
 	describe('allTools', () => {
-		it('aggregates all 39 tool definitions', () => {
-			expect(allTools.length).toBe(39);
+		it('aggregates all 40 tool definitions', () => {
+			expect(allTools.length).toBe(40);
 		});
 
 		it('contains known tools from different files', () => {
@@ -281,7 +281,7 @@ describe('tools/registry', () => {
 			const server = createMockServer();
 			const session = createMockSession();
 			registerAllTools(server as unknown as McpServer, session);
-			expect(server.registeredTools.size).toBe(39);
+			expect(server.registeredTools.size).toBe(40);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `wp_view_post` — a read-only tool that fetches any post by ID via REST and renders it through the existing `renderPost` formatter, without touching the Y.Doc. Available in both `connected` and `editing` states, so the open editing session is undisturbed.
- Surfaces the new tool in the Compose discovery phase and the Edit prompt's tool list, so the assistant knows to reach for it when researching.
- Reuses existing infrastructure: `apiClient.getPost`, `parseBlocks` / `parsedBlockToBlock`, `renderPost`, and `apiClient.getTerms` for category/tag resolution. Term lookups are best-effort — failures omit the metadata rather than fail the call.

Closes #81.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 1224 passing (added unit tests for `viewPost` happy path, undisturbed editing state, term-lookup failure, and disconnected error; tool-level tests for registration, success, error, and `availableIn`)
- [ ] `npm run lint` — clean
- [ ] Manual: from `connected`, run `wp_view_post {postId: <id>}` → returns rendered post
- [ ] Manual: with a post open, run `wp_view_post` on a different post → returns the other post; `wp_read_post` on the open post is unchanged
- [ ] Manual: `wp_view_post {postId: 999999}` → tool result is `isError: true` with a recognisable 404 message