### PR TITLE
fix: roll back post state when openPost fails after addRoom

### DIFF
--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -628,6 +628,27 @@ export class SessionManager {
 			},
 		});
 
+		try {
+			await this._finishOpenPost(post, doc, syncClient, room);
+		} catch (error) {
+			// Roll back every piece of state allocated so far so the session
+			// stays on 'connected' and the next openPost call can succeed.
+			await this._tearDownPost();
+			throw error;
+		}
+	}
+
+	/**
+	 * Finish opening the post after the post room has been added to the
+	 * SyncClient. Split out from openPost() so the error path can restore
+	 * state without duplicating the setup code.
+	 */
+	private async _finishOpenPost(
+		post: WPPost,
+		doc: Y.Doc,
+		syncClient: SyncClient,
+		room: string
+	): Promise<void> {
 		// Wait for the sync handshake to populate the doc with remote content.
 		// The handshake takes multiple poll cycles:
 		//   Poll 1: We send sync_step1 → receive peer's sync_step1
@@ -854,7 +875,21 @@ export class SessionManager {
 	async closePost(): Promise<void> {
 		this.requireState('editing');
 		await this.drainStreamQueue();
+		await this._tearDownPost();
+		this.state = 'connected';
+	}
 
+	/**
+	 * Tear down all post-scoped state. Shared by closePost() and the
+	 * openPost() error-recovery path.
+	 *
+	 * Does NOT drain the streaming queue (closePost does that first) and
+	 * does NOT change this.state — callers are responsible for transitioning
+	 * state appropriately. Safe to call when only some of the state has
+	 * been established (removeRoom is a no-op for unregistered rooms, and
+	 * handlers are only detached when both the doc and handler are set).
+	 */
+	private async _tearDownPost(): Promise<void> {
 		// Remove post and comment rooms from the SyncClient (it stays alive
 		// with the command room for the duration of the connection).
 		if (this._syncClient && this.postRoom) {
@@ -866,13 +901,13 @@ export class SessionManager {
 
 		if (this._doc && this.updateHandler) {
 			this._doc.off('updateV2', this.updateHandler);
-			this.updateHandler = null;
 		}
+		this.updateHandler = null;
 
 		if (this.commentDoc && this.commentUpdateHandler) {
 			this.commentDoc.off('updateV2', this.commentUpdateHandler);
-			this.commentUpdateHandler = null;
 		}
+		this.commentUpdateHandler = null;
 
 		if (this.postHealthCheckTimer !== null) {
 			clearInterval(this.postHealthCheckTimer);
@@ -896,7 +931,6 @@ export class SessionManager {
 		this.postGone = false;
 		this.postGoneReason = null;
 		this.postGoneCheck = null;
-		this.state = 'connected';
 	}
 
 	// --- Reading ---
@@ -1895,10 +1929,18 @@ export class SessionManager {
 		// sentinel and the next caller checking it).
 		const previous = this._preOpenInProgress;
 		const current = (async () => {
-			if (previous) await previous;
-			await this._doPreOpenPost(postId).catch(() => {
-				// Errors are best-effort — the command handler already catches them.
-			});
+			// Swallow errors from the previous call so they don't cascade
+			// into this one, but surface errors from _this_ call to the
+			// caller — the command handler retries and the cloud
+			// orchestrator treats open-failures as command failures.
+			if (previous) {
+				try {
+					await previous;
+				} catch {
+					// Previous caller already observed (or swallowed) this.
+				}
+			}
+			await this._doPreOpenPost(postId);
 		})();
 		this._preOpenInProgress = current;
 		await current;

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -606,33 +606,35 @@ export class SessionManager {
 		this.postRoom = room;
 		const initialUpdates = [createSyncStep1(doc)];
 
-		syncClient.addRoom(room, doc.clientID, initialUpdates, {
-			onUpdate: (update) => {
-				try {
-					return processIncomingUpdate(doc, update);
-				} catch {
-					return null;
-				}
-			},
-			onAwareness: (awarenessState) => {
-				this.collaborators = parseCollaborators(
-					awarenessState,
-					doc.clientID
-				);
-			},
-			onCompactionRequested: () => {
-				return createCompactionUpdate(doc);
-			},
-			getAwarenessState: () => {
-				return this.awarenessState;
-			},
-		});
-
 		try {
+			syncClient.addRoom(room, doc.clientID, initialUpdates, {
+				onUpdate: (update) => {
+					try {
+						return processIncomingUpdate(doc, update);
+					} catch {
+						return null;
+					}
+				},
+				onAwareness: (awarenessState) => {
+					this.collaborators = parseCollaborators(
+						awarenessState,
+						doc.clientID
+					);
+				},
+				onCompactionRequested: () => {
+					return createCompactionUpdate(doc);
+				},
+				getAwarenessState: () => {
+					return this.awarenessState;
+				},
+			});
+
 			await this._finishOpenPost(post, doc, syncClient, room);
 		} catch (error) {
 			// Roll back every piece of state allocated so far so the session
 			// stays on 'connected' and the next openPost call can succeed.
+			// removeRoom is a no-op for an unregistered room, so this is
+			// safe even when addRoom itself threw.
 			await this._tearDownPost();
 			throw error;
 		}

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -476,6 +476,32 @@ describe('SessionManager', () => {
 	});
 
 	describe('openPost() error recovery', () => {
+		it('rolls back post state when the post-room addRoom fails', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			await session.connect(fakeConfig);
+			mockGetPost.mockResolvedValue(fakePost);
+
+			// Simulate SyncClient.addRoom throwing on the very first call —
+			// e.g. the "Room already registered" case that motivated this fix.
+			mockSyncAddRoom.mockImplementationOnce(() => {
+				throw new Error('already registered');
+			});
+
+			await expect(session.openPost(42)).rejects.toThrow(
+				'already registered'
+			);
+
+			expect(session.getState()).toBe('connected');
+			expect(session.getCurrentPost()).toBeNull();
+
+			// A retry must succeed — before the fix, _currentPost / _doc /
+			// postRoom were left dangling when addRoom itself threw.
+			await session.openPost(42);
+			expect(session.getState()).toBe('editing');
+			expect(session.getCurrentPost()?.id).toBe(42);
+		});
+
 		it('rolls back post state when comment-room addRoom fails', async () => {
 			mockValidateConnection.mockResolvedValue(fakeUser);
 			mockValidateSyncEndpoint.mockResolvedValue(undefined);

--- a/tests/unit/session-manager.test.ts
+++ b/tests/unit/session-manager.test.ts
@@ -475,6 +475,147 @@ describe('SessionManager', () => {
 		});
 	});
 
+	describe('openPost() error recovery', () => {
+		it('rolls back post state when comment-room addRoom fails', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			// Enable notes so the second addRoom call is issued.
+			mockCheckNotesSupport.mockResolvedValue(true);
+			await session.connect(fakeConfig);
+
+			mockGetPost.mockResolvedValue(fakePost);
+
+			// Succeed for the post room, fail for the comment room.
+			let addRoomCalls = 0;
+			mockSyncAddRoom.mockImplementation(() => {
+				addRoomCalls++;
+				if (addRoomCalls === 2) {
+					throw new Error('boom');
+				}
+			});
+
+			await expect(session.openPost(42)).rejects.toThrow('boom');
+
+			expect(session.getState()).toBe('connected');
+			expect(session.getCurrentPost()).toBeNull();
+			// The post room was removed during rollback.
+			expect(mockSyncRemoveRoom).toHaveBeenCalledWith('postType/post:42');
+		});
+
+		it('allows a retry to succeed on the same post after a failed open', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			mockCheckNotesSupport.mockResolvedValue(true);
+			await session.connect(fakeConfig);
+			mockGetPost.mockResolvedValue(fakePost);
+
+			// Fail once on the comment room, then succeed for all subsequent calls.
+			let addRoomCalls = 0;
+			mockSyncAddRoom.mockImplementation(() => {
+				addRoomCalls++;
+				if (addRoomCalls === 2) {
+					throw new Error('transient');
+				}
+			});
+
+			await expect(session.openPost(42)).rejects.toThrow('transient');
+
+			// The retry uses the cleaned-up state and must succeed — previously
+			// it threw "Room 'postType/post:42' is already registered".
+			await session.openPost(42);
+
+			expect(session.getState()).toBe('editing');
+			expect(session.getCurrentPost()?.id).toBe(42);
+		});
+
+		it('leaves the session usable when getPost rejects before any sync state is allocated', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			await session.connect(fakeConfig);
+
+			mockGetPost.mockRejectedValueOnce(new Error('404'));
+
+			await expect(session.openPost(42)).rejects.toThrow('404');
+
+			expect(session.getState()).toBe('connected');
+			expect(session.getCurrentPost()).toBeNull();
+
+			mockGetPost.mockResolvedValueOnce(fakePost);
+			await session.openPost(42);
+			expect(session.getState()).toBe('editing');
+		});
+
+		it('clears the currentPost reference set before addRoom', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			mockCheckNotesSupport.mockResolvedValue(true);
+			await session.connect(fakeConfig);
+			mockGetPost.mockResolvedValue(fakePost);
+
+			let addRoomCalls = 0;
+			mockSyncAddRoom.mockImplementation(() => {
+				addRoomCalls++;
+				if (addRoomCalls === 2) {
+					throw new Error('comment-room-failure');
+				}
+			});
+
+			await expect(session.openPost(42)).rejects.toThrow(
+				'comment-room-failure'
+			);
+
+			// Before the fix, _currentPost was left referencing the post.
+			expect(session.getCurrentPost()).toBeNull();
+		});
+	});
+
+	describe('preOpenPost() error recovery', () => {
+		it('propagates errors to the caller', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			mockCheckNotesSupport.mockResolvedValue(true);
+			await session.connect(fakeConfig);
+			mockGetPost.mockResolvedValue(fakePost);
+
+			let addRoomCalls = 0;
+			mockSyncAddRoom.mockImplementation(() => {
+				addRoomCalls++;
+				if (addRoomCalls === 2) {
+					throw new Error('boom');
+				}
+			});
+
+			// Previously preOpenPost silently swallowed — callers (like the
+			// cloud orchestrator) couldn't see open-failures. It now rejects
+			// so the caller can treat it as a command-level failure.
+			await expect(session.preOpenPost(42)).rejects.toThrow('boom');
+
+			expect(session.getState()).toBe('connected');
+			expect(session.getCurrentPost()).toBeNull();
+		});
+
+		it('surfaces a failure from its own call even after a previous preOpenPost rejected', async () => {
+			mockValidateConnection.mockResolvedValue(fakeUser);
+			mockValidateSyncEndpoint.mockResolvedValue(undefined);
+			mockCheckNotesSupport.mockResolvedValue(true);
+			await session.connect(fakeConfig);
+			mockGetPost.mockResolvedValue(fakePost);
+
+			let addRoomCalls = 0;
+			mockSyncAddRoom.mockImplementation(() => {
+				addRoomCalls++;
+				if (addRoomCalls === 2 || addRoomCalls === 4) {
+					throw new Error(`fail-${addRoomCalls}`);
+				}
+			});
+
+			await expect(session.preOpenPost(42)).rejects.toThrow('fail-2');
+			// The second call must not inherit the previous rejection —
+			// it must surface its own failure.
+			await expect(session.preOpenPost(42)).rejects.toThrow('fail-4');
+		});
+	});
+
 	describe('closePost()', () => {
 		it('removes post room and clears doc', async () => {
 			await connectAndOpen(session);


### PR DESCRIPTION
## Summary

- `SessionManager.openPost()` could leave the session holding a registered room, live update handlers, and a health-check timer if the sync handshake or any follow-up step threw. The next `openPost` on the same post then hit `"Room 'postType/post:N' is already registered"` in `SyncClient.addRoom`.
- Wrap the post-`addRoom` steps in a try/catch backed by a new `_tearDownPost()` helper (shared with `closePost`) that removes rooms, detaches handlers, clears the timer, and resets cached fields. State stays on `'connected'` so a retry succeeds.
- Stop `preOpenPost` silently swallowing errors so the cloud orchestrator can surface open-failures as command failures. Previous-call rejections are still swallowed so they don't cascade into later callers. The existing command-handler caller already wraps the call in try/catch.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 1230 tests pass, including 6 new tests covering:
  - Rollback on comment-room `addRoom` failure
  - Retry on the same post succeeding after a previous failure
  - `getPost` rejecting before any sync state is allocated
  - `_currentPost` cleared on rollback
  - `preOpenPost` propagating errors to the caller
  - `preOpenPost` not inheriting the previous call's rejection
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Re-run in the cloud repo against the file-dep build to confirm `preOpenPost` surfaces open-failures as command failures